### PR TITLE
feat: batched upload with month-by-month processing for large archives

### DIFF
--- a/adapters/adapters.go
+++ b/adapters/adapters.go
@@ -31,6 +31,15 @@ type Runner interface {
 	Run(cmd *cobra.Command, adapter Reader) error
 }
 
+// MonthNoDate is the sentinel value used to represent assets with no
+// determinable date in the month-based batching system.
+const MonthNoDate = "no-date"
+
+// TimeToMonth formats a time.Time as a "YYYY-MM" month string.
+func TimeToMonth(t time.Time) string {
+	return fmt.Sprintf("%04d-%02d", t.Year(), t.Month())
+}
+
 // MonthToDateRange converts a "YYYY-MM" string to a date range with
 // ±1 day padding for timezone safety.
 // For example, "2022-06" returns:

--- a/adapters/adapters.go
+++ b/adapters/adapters.go
@@ -2,6 +2,8 @@ package adapters
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	"github.com/simulot/immich-go/internal/assets"
 	"github.com/spf13/cobra"
@@ -11,6 +13,15 @@ type Reader interface {
 	Browse(cxt context.Context) chan *assets.Group
 }
 
+// DateRangeProvider is an optional interface for adapters that support
+// date-aware browsing (batched upload mode). If an adapter does not
+// implement DateRangeProvider, the upload command falls back to the
+// current behavior (full index, no batching).
+type DateRangeProvider interface {
+	PreScan(ctx context.Context) (months []string, err error)
+	BrowseMonth(ctx context.Context, month string) chan *assets.Group
+}
+
 type AssetWriter interface {
 	WriteAsset(context.Context, *assets.Asset) error
 	// WriteGroup(ctx context.Context, group *assets.Group) error
@@ -18,4 +29,20 @@ type AssetWriter interface {
 
 type Runner interface {
 	Run(cmd *cobra.Command, adapter Reader) error
+}
+
+// MonthToDateRange converts a "YYYY-MM" string to a date range with
+// ±1 day padding for timezone safety.
+// For example, "2022-06" returns:
+//
+//	after  = 2022-05-31 00:00:00 UTC
+//	before = 2022-07-02 00:00:00 UTC
+func MonthToDateRange(month string) (after, before time.Time, err error) {
+	t, err := time.Parse("2006-01", month)
+	if err != nil {
+		return time.Time{}, time.Time{}, fmt.Errorf("invalid month %q: %w", month, err)
+	}
+	after = t.AddDate(0, 0, -1)                // first of month minus 1 day
+	before = t.AddDate(0, 1, 0).AddDate(0, 0, 1) // first of next month plus 1 day
+	return after, before, nil
 }

--- a/adapters/folder/browsemonth_test.go
+++ b/adapters/folder/browsemonth_test.go
@@ -1,0 +1,309 @@
+package folder
+
+import (
+	"context"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/simulot/immich-go/adapters"
+	"github.com/simulot/immich-go/internal/assets"
+	"github.com/simulot/immich-go/internal/assettracker"
+	"github.com/simulot/immich-go/internal/fileevent"
+	"github.com/simulot/immich-go/internal/filenames"
+	"github.com/simulot/immich-go/internal/fileprocessor"
+	"github.com/simulot/immich-go/internal/filetypes"
+	"github.com/simulot/immich-go/internal/groups"
+	"github.com/simulot/immich-go/internal/groups/series"
+	"github.com/simulot/immich-go/internal/worker"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- MonthToDateRange tests ---
+
+func TestMonthToDateRange(t *testing.T) {
+	tests := []struct {
+		name        string
+		month       string
+		expectAfter time.Time
+		expectBefore time.Time
+		expectErr   bool
+	}{
+		{
+			name:         "June 2022",
+			month:        "2022-06",
+			expectAfter:  time.Date(2022, 5, 31, 0, 0, 0, 0, time.UTC),
+			expectBefore: time.Date(2022, 7, 2, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:         "January 2020 (year boundary)",
+			month:        "2020-01",
+			expectAfter:  time.Date(2019, 12, 31, 0, 0, 0, 0, time.UTC),
+			expectBefore: time.Date(2020, 2, 2, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:         "December 2023 (year boundary end)",
+			month:        "2023-12",
+			expectAfter:  time.Date(2023, 11, 30, 0, 0, 0, 0, time.UTC),
+			expectBefore: time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:         "February 2024 (leap year)",
+			month:        "2024-02",
+			expectAfter:  time.Date(2024, 1, 31, 0, 0, 0, 0, time.UTC),
+			expectBefore: time.Date(2024, 3, 2, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:      "invalid format",
+			month:     "2022",
+			expectErr: true,
+		},
+		{
+			name:      "invalid month string",
+			month:     "not-a-date",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			after, before, err := adapters.MonthToDateRange(tc.month)
+			if tc.expectErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectAfter, after, "after mismatch")
+			assert.Equal(t, tc.expectBefore, before, "before mismatch")
+		})
+	}
+}
+
+func TestMonthToDateRange_Padding(t *testing.T) {
+	// Verify that a date on the last day of the previous month is included
+	after, before, err := adapters.MonthToDateRange("2022-06")
+	require.NoError(t, err)
+
+	// May 31 at 23:59 should be in range (>= after)
+	may31 := time.Date(2022, 5, 31, 23, 59, 59, 0, time.UTC)
+	assert.True(t, (may31.Equal(after) || may31.After(after)) && may31.Before(before),
+		"May 31 23:59 should be in padded range")
+
+	// July 1 at 23:59 should be in range (< before which is July 2)
+	jul1 := time.Date(2022, 7, 1, 23, 59, 59, 0, time.UTC)
+	assert.True(t, (jul1.Equal(after) || jul1.After(after)) && jul1.Before(before),
+		"July 1 23:59 should be in padded range")
+
+	// July 2 at 00:00 should NOT be in range (== before, exclusive)
+	jul2 := time.Date(2022, 7, 2, 0, 0, 0, 0, time.UTC)
+	assert.False(t, jul2.Before(before),
+		"July 2 00:00 should NOT be in padded range")
+}
+
+// --- BrowseMonth tests ---
+
+// newTestIFC creates a minimal ImportFolderCmd suitable for testing BrowseMonth.
+// It creates temp files with date-bearing filenames in the given directory.
+func newTestIFC(t *testing.T, dir string) *ImportFolderCmd {
+	t.Helper()
+	tz := time.UTC
+	sm := filetypes.DefaultSupportedMedia
+
+	logger := slog.Default()
+	recorder := fileevent.NewRecorder(logger)
+	tracker := assettracker.New()
+	proc := fileprocessor.New(tracker, recorder)
+
+	ifc := &ImportFolderCmd{
+		Recursive:      true,
+		tz:             tz,
+		supportedMedia: sm,
+		infoCollector:  filenames.NewInfoCollector(tz, sm),
+		fsyss:          []fs.FS{os.DirFS(dir)},
+		activeMonthSet: make(map[string]struct{}),
+		pool:           worker.NewPool(1),
+		groupers:       []groups.Grouper{series.Group},
+		processor:      proc,
+	}
+	return ifc
+}
+
+func TestBrowseMonth_FiltersCorrectMonth(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create files with dates in different months and set their mod times
+	// to match the date in their name, since assetDate checks FileDate before Taken.
+	type testFile struct {
+		name    string
+		modTime time.Time
+	}
+	// Note: MonthToDateRange uses ±1 day padding for timezone safety.
+	// For "2022-06", the range is [2022-05-31, 2022-07-02).
+	// So 2022-07-01 is still within the padded range.
+	// We use 2022-07-10 and 2023-01-15 as clearly-outside dates.
+	files := []testFile{
+		{"IMG_20220601_120000.jpg", time.Date(2022, 6, 1, 12, 0, 0, 0, time.UTC)},
+		{"IMG_20220615_120000.jpg", time.Date(2022, 6, 15, 12, 0, 0, 0, time.UTC)},
+		{"IMG_20220710_120000.jpg", time.Date(2022, 7, 10, 12, 0, 0, 0, time.UTC)},
+		{"IMG_20230115_120000.jpg", time.Date(2023, 1, 15, 12, 0, 0, 0, time.UTC)},
+	}
+	for _, f := range files {
+		p := filepath.Join(dir, f.name)
+		err := os.WriteFile(p, []byte("fake"), 0o644)
+		require.NoError(t, err)
+		err = os.Chtimes(p, f.modTime, f.modTime)
+		require.NoError(t, err)
+	}
+
+	ifc := newTestIFC(t, dir)
+
+	ctx := context.Background()
+	ch := ifc.BrowseMonth(ctx, "2022-06")
+
+	var collected []string
+	for g := range ch {
+		for _, a := range g.Assets {
+			collected = append(collected, a.OriginalFileName)
+		}
+	}
+
+	assert.Contains(t, collected, "IMG_20220601_120000.jpg")
+	assert.Contains(t, collected, "IMG_20220615_120000.jpg")
+	assert.NotContains(t, collected, "IMG_20220710_120000.jpg")
+	assert.NotContains(t, collected, "IMG_20230115_120000.jpg")
+}
+
+func TestBrowseMonth_NoDateIncluded(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a file with no date in the name and a mod time in August 2023
+	randomPath := filepath.Join(dir, "random_photo.jpg")
+	err := os.WriteFile(randomPath, []byte("fake"), 0o644)
+	require.NoError(t, err)
+	err = os.Chtimes(randomPath, time.Date(2023, 8, 10, 0, 0, 0, 0, time.UTC),
+		time.Date(2023, 8, 10, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+
+	// Also create a date-bearing file with matching mod time
+	junePath := filepath.Join(dir, "IMG_20220601_120000.jpg")
+	err = os.WriteFile(junePath, []byte("fake"), 0o644)
+	require.NoError(t, err)
+	err = os.Chtimes(junePath, time.Date(2022, 6, 1, 12, 0, 0, 0, time.UTC),
+		time.Date(2022, 6, 1, 12, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+
+	ifc := newTestIFC(t, dir)
+
+	ctx := context.Background()
+
+	// BrowseMonth("2022-06") should only yield the June file, not the random file
+	// (random_photo.jpg has FileDate of 2023-08-10, outside June 2022 range)
+	ch := ifc.BrowseMonth(ctx, "2022-06")
+
+	var collected []string
+	for g := range ch {
+		for _, a := range g.Assets {
+			collected = append(collected, a.OriginalFileName)
+		}
+	}
+
+	assert.Contains(t, collected, "IMG_20220601_120000.jpg")
+	assert.NotContains(t, collected, "random_photo.jpg",
+		"random_photo.jpg has Aug 2023 FileDate, should not appear in 2022-06")
+}
+
+func TestBrowseMonth_NoDateBucket(t *testing.T) {
+	// Test that BrowseMonth with "no-date" works for the assetDate helper.
+	// Since we can't easily make a file with zero FileDate through the filesystem,
+	// we test the assetDate function directly.
+
+	// Asset with no dates at all
+	a := &assets.Asset{}
+	d := assetDate(a)
+	assert.True(t, d.IsZero(), "asset with no dates should have zero date")
+
+	// Asset with CaptureDate
+	a2 := &assets.Asset{CaptureDate: time.Date(2022, 6, 1, 0, 0, 0, 0, time.UTC)}
+	d2 := assetDate(a2)
+	assert.Equal(t, time.Date(2022, 6, 1, 0, 0, 0, 0, time.UTC), d2)
+
+	// Asset with only FileDate
+	a3 := &assets.Asset{FileDate: time.Date(2023, 1, 15, 0, 0, 0, 0, time.UTC)}
+	d3 := assetDate(a3)
+	assert.Equal(t, time.Date(2023, 1, 15, 0, 0, 0, 0, time.UTC), d3)
+
+	// Asset with only NameInfo.Taken
+	a4 := &assets.Asset{}
+	a4.NameInfo.Taken = time.Date(2021, 3, 10, 0, 0, 0, 0, time.UTC)
+	d4 := assetDate(a4)
+	assert.Equal(t, time.Date(2021, 3, 10, 0, 0, 0, 0, time.UTC), d4)
+}
+
+func TestAssetDate_ResolutionOrder(t *testing.T) {
+	// CaptureDate takes precedence over FileDate and Taken
+	a := &assets.Asset{
+		CaptureDate: time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
+		FileDate:    time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	a.NameInfo.Taken = time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	assert.Equal(t, time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC), assetDate(a))
+
+	// FileDate takes precedence over Taken when CaptureDate is zero
+	a2 := &assets.Asset{
+		FileDate: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	a2.NameInfo.Taken = time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	assert.Equal(t, time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC), assetDate(a2))
+
+	// Taken is used when CaptureDate and FileDate are both zero
+	a3 := &assets.Asset{}
+	a3.NameInfo.Taken = time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	assert.Equal(t, time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), assetDate(a3))
+}
+
+func TestBrowse_StillWorks(t *testing.T) {
+	// Backward compatibility: Browse() should still return all assets
+	dir := t.TempDir()
+
+	type testFile struct {
+		name    string
+		modTime time.Time
+	}
+	files := []testFile{
+		{"IMG_20220601_120000.jpg", time.Date(2022, 6, 1, 12, 0, 0, 0, time.UTC)},
+		{"IMG_20220701_120000.jpg", time.Date(2022, 7, 1, 12, 0, 0, 0, time.UTC)},
+		{"IMG_20230115_120000.jpg", time.Date(2023, 1, 15, 12, 0, 0, 0, time.UTC)},
+	}
+	for _, f := range files {
+		p := filepath.Join(dir, f.name)
+		err := os.WriteFile(p, []byte("fake"), 0o644)
+		require.NoError(t, err)
+		err = os.Chtimes(p, f.modTime, f.modTime)
+		require.NoError(t, err)
+	}
+
+	ifc := newTestIFC(t, dir)
+
+	ctx := context.Background()
+	ch := ifc.Browse(ctx)
+
+	var collected []string
+	for g := range ch {
+		for _, a := range g.Assets {
+			collected = append(collected, a.OriginalFileName)
+		}
+	}
+
+	// All files should be present
+	assert.Len(t, collected, 3)
+	assert.Contains(t, collected, "IMG_20220601_120000.jpg")
+	assert.Contains(t, collected, "IMG_20220701_120000.jpg")
+	assert.Contains(t, collected, "IMG_20230115_120000.jpg")
+}
+
+// Verify that ImportFolderCmd implements DateRangeProvider at compile time.
+var _ adapters.DateRangeProvider = (*ImportFolderCmd)(nil)

--- a/adapters/folder/commands.go
+++ b/adapters/folder/commands.go
@@ -2,7 +2,10 @@ package folder
 
 import (
 	"context"
+	"fmt"
 	"io/fs"
+	"path/filepath"
+	"sort"
 	"sync"
 	"time"
 
@@ -52,6 +55,168 @@ type ImportFolderCmd struct {
 	picasaAlbums            *gen.SyncMap[string, PicasaAlbum] // ap[string]PicasaAlbum
 	icloudMetas             *gen.SyncMap[string, iCloudMeta]
 	icloudMetaPass          bool
+
+	// Pre-scan date tracking
+	monthsMu       sync.Mutex
+	activeMonthSet map[string]struct{} // set of YYYY-MM strings discovered during pre-scan
+	activeMonths   []string            // sorted list of YYYY-MM strings (populated after pre-scan)
+	hasNoDateFiles bool                // whether files with no determinable date were found
+}
+
+// addMonth extracts the YYYY-MM string from a time.Time and adds it to the
+// active months set. It is safe for concurrent use.
+func (ifc *ImportFolderCmd) addMonth(t time.Time) {
+	if t.IsZero() {
+		return
+	}
+	month := fmt.Sprintf("%04d-%02d", t.Year(), t.Month())
+	ifc.monthsMu.Lock()
+	defer ifc.monthsMu.Unlock()
+	if ifc.activeMonthSet == nil {
+		ifc.activeMonthSet = make(map[string]struct{})
+	}
+	ifc.activeMonthSet[month] = struct{}{}
+}
+
+// setNoDateFiles marks that at least one file with no determinable date was found.
+func (ifc *ImportFolderCmd) setNoDateFiles() {
+	ifc.monthsMu.Lock()
+	defer ifc.monthsMu.Unlock()
+	ifc.hasNoDateFiles = true
+}
+
+// buildSortedMonths converts the activeMonthSet into a sorted slice and stores it in activeMonths.
+func (ifc *ImportFolderCmd) buildSortedMonths() {
+	ifc.monthsMu.Lock()
+	defer ifc.monthsMu.Unlock()
+	ifc.activeMonths = make([]string, 0, len(ifc.activeMonthSet))
+	for m := range ifc.activeMonthSet {
+		ifc.activeMonths = append(ifc.activeMonths, m)
+	}
+	sort.Strings(ifc.activeMonths)
+}
+
+// ActiveMonths returns the sorted list of YYYY-MM strings discovered during pre-scan.
+func (ifc *ImportFolderCmd) ActiveMonths() []string {
+	ifc.monthsMu.Lock()
+	defer ifc.monthsMu.Unlock()
+	result := make([]string, len(ifc.activeMonths))
+	copy(result, ifc.activeMonths)
+	return result
+}
+
+// HasNoDateFiles returns whether files with no determinable date were found during pre-scan.
+func (ifc *ImportFolderCmd) HasNoDateFiles() bool {
+	ifc.monthsMu.Lock()
+	defer ifc.monthsMu.Unlock()
+	return ifc.hasNoDateFiles
+}
+
+// PreScan runs the iCloud CSV first pass (if applicable) and walks local files
+// to extract dates from filenames using InfoCollector. It returns a sorted unique
+// list of YYYY-MM strings representing months that have assets.
+func (ifc *ImportFolderCmd) PreScan(ctx context.Context) ([]string, error) {
+	// Initialize month set
+	ifc.monthsMu.Lock()
+	ifc.activeMonthSet = make(map[string]struct{})
+	ifc.hasNoDateFiles = false
+	ifc.monthsMu.Unlock()
+
+	// For iCloud takeouts, run the CSV meta pass first
+	if ifc.ICloudTakeout && ifc.icloudMetas != nil {
+		// Iterate over already-parsed iCloud metas to collect dates
+		ifc.icloudMetas.Range(func(_ string, meta iCloudMeta) bool {
+			if !meta.originalCreationDate.IsZero() {
+				ifc.addMonth(meta.originalCreationDate)
+			}
+			return true
+		})
+	}
+
+	// Walk local files to extract dates from filenames
+	if ifc.infoCollector == nil {
+		ifc.infoCollector = filenames.NewInfoCollector(ifc.tz, ifc.supportedMedia)
+	}
+
+	for _, fsys := range ifc.fsyss {
+		err := ifc.preScanDir(ctx, fsys, ".")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	ifc.buildSortedMonths()
+	return ifc.ActiveMonths(), nil
+}
+
+// preScanDir walks a directory to extract dates from filenames for pre-scan.
+func (ifc *ImportFolderCmd) preScanDir(ctx context.Context, fsys fs.FS, dir string) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	entries, err := fs.ReadDir(fsys, dir)
+	if err != nil {
+		return err
+	}
+
+	fsName := ""
+	if named, ok := fsys.(interface{ Name() string }); ok {
+		fsName = named.Name()
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			if ifc.Recursive && entry.Name() != "." {
+				subDir := dir + "/" + entry.Name()
+				if dir == "." {
+					subDir = entry.Name()
+				}
+				if err := ifc.preScanDir(ctx, fsys, subDir); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+
+		base := entry.Name()
+		ext := filepath.Ext(base)
+
+		// Skip CSV and non-media files
+		if ext == icloudMetadataExt {
+			continue
+		}
+		mediaType := ifc.supportedMedia.TypeFromExt(ext)
+		if mediaType != filetypes.TypeImage && mediaType != filetypes.TypeVideo {
+			continue
+		}
+
+		// Build a full path for the info collector
+		name := dir + "/" + base
+		if dir == "." {
+			name = base
+		}
+		n := name
+		if fsName != "" {
+			n = fsName + "/" + n
+		}
+
+		info := ifc.infoCollector.GetInfo(n)
+		if !info.Taken.IsZero() {
+			ifc.addMonth(info.Taken)
+		} else {
+			// Try file modification time as fallback
+			fi, err := fs.Stat(fsys, name)
+			if err == nil && !fi.ModTime().IsZero() {
+				ifc.addMonth(fi.ModTime())
+			} else {
+				ifc.setNoDateFiles()
+			}
+		}
+	}
+	return nil
 }
 
 func (ifc *ImportFolderCmd) RegisterFlags(flags *pflag.FlagSet, cmd *cobra.Command) {

--- a/adapters/folder/commands.go
+++ b/adapters/folder/commands.go
@@ -2,10 +2,8 @@ package folder
 
 import (
 	"context"
-	"fmt"
 	"io/fs"
 	"path/filepath"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -65,7 +63,7 @@ type ImportFolderCmd struct {
 
 	// Month filter for BrowseMonth — when set, parseDir skips files
 	// not matching this month BEFORE extracting from zip.
-	targetMonth  string    // "YYYY-MM", "no-date", or "" (no filter)
+	targetMonth  string    // "YYYY-MM", adapters.MonthNoDate, or "" (no filter)
 	targetAfter  time.Time // inclusive lower bound
 	targetBefore time.Time // exclusive upper bound
 }
@@ -76,7 +74,7 @@ func (ifc *ImportFolderCmd) addMonth(t time.Time) {
 	if t.IsZero() {
 		return
 	}
-	month := fmt.Sprintf("%04d-%02d", t.Year(), t.Month())
+	month := adapters.TimeToMonth(t)
 	ifc.monthsMu.Lock()
 	defer ifc.monthsMu.Unlock()
 	if ifc.activeMonthSet == nil {
@@ -96,11 +94,7 @@ func (ifc *ImportFolderCmd) setNoDateFiles() {
 func (ifc *ImportFolderCmd) buildSortedMonths() {
 	ifc.monthsMu.Lock()
 	defer ifc.monthsMu.Unlock()
-	ifc.activeMonths = make([]string, 0, len(ifc.activeMonthSet))
-	for m := range ifc.activeMonthSet {
-		ifc.activeMonths = append(ifc.activeMonths, m)
-	}
-	sort.Strings(ifc.activeMonths)
+	ifc.activeMonths = gen.MapKeysSorted(ifc.activeMonthSet)
 }
 
 // ActiveMonths returns the sorted list of YYYY-MM strings discovered during pre-scan.
@@ -270,8 +264,11 @@ func (ifc *ImportFolderCmd) preScanDir(ctx context.Context, fsys fs.FS, dir stri
 		if !info.Taken.IsZero() {
 			ifc.addMonth(info.Taken)
 		} else {
-			// Try file modification time as fallback
-			fi, err := fs.Stat(fsys, name)
+			// Use entry.Info() instead of fs.Stat() — for zip filesystems,
+			// fs.Stat opens each file (seeking into the zip body) just to
+			// read metadata that's already in the central directory.
+			// entry.Info() returns the same data without any I/O.
+			fi, err := entry.Info()
 			if err == nil && !fi.ModTime().IsZero() {
 				ifc.addMonth(fi.ModTime())
 			} else {

--- a/adapters/folder/commands.go
+++ b/adapters/folder/commands.go
@@ -61,6 +61,12 @@ type ImportFolderCmd struct {
 	activeMonthSet map[string]struct{} // set of YYYY-MM strings discovered during pre-scan
 	activeMonths   []string            // sorted list of YYYY-MM strings (populated after pre-scan)
 	hasNoDateFiles bool                // whether files with no determinable date were found
+
+	// Month filter for BrowseMonth — when set, parseDir skips files
+	// not matching this month BEFORE extracting from zip.
+	targetMonth  string    // "YYYY-MM", "no-date", or "" (no filter)
+	targetAfter  time.Time // inclusive lower bound
+	targetBefore time.Time // exclusive upper bound
 }
 
 // addMonth extracts the YYYY-MM string from a time.Time and adds it to the

--- a/adapters/folder/commands.go
+++ b/adapters/folder/commands.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -128,9 +129,17 @@ func (ifc *ImportFolderCmd) PreScan(ctx context.Context) ([]string, error) {
 	ifc.hasNoDateFiles = false
 	ifc.monthsMu.Unlock()
 
-	// For iCloud takeouts, run the CSV meta pass first
+	// For iCloud takeouts, parse Photo Details CSVs to get dates.
+	// This must happen before the filename-based scan because iCloud
+	// uses UUID filenames that don't contain date information.
 	if ifc.ICloudTakeout && ifc.icloudMetas != nil {
-		// Iterate over already-parsed iCloud metas to collect dates
+		for _, fsys := range ifc.fsyss {
+			if err := ifc.preScanICloudCSVs(ctx, fsys, "."); err != nil {
+				return nil, err
+			}
+		}
+		// Collect months from all iCloud metas (parsed from CSVs above,
+		// or pre-populated by caller)
 		ifc.icloudMetas.Range(func(_ string, meta iCloudMeta) bool {
 			if !meta.originalCreationDate.IsZero() {
 				ifc.addMonth(meta.originalCreationDate)
@@ -153,6 +162,54 @@ func (ifc *ImportFolderCmd) PreScan(ctx context.Context) ([]string, error) {
 
 	ifc.buildSortedMonths()
 	return ifc.ActiveMonths(), nil
+}
+
+// preScanICloudCSVs walks the filesystem to find and parse Photo Details CSV
+// files, populating icloudMetas with dates and collecting active months.
+func (ifc *ImportFolderCmd) preScanICloudCSVs(ctx context.Context, fsys fs.FS, dir string) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	entries, err := fs.ReadDir(fsys, dir)
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			subDir := dir + "/" + entry.Name()
+			if dir == "." {
+				subDir = entry.Name()
+			}
+			if err := ifc.preScanICloudCSVs(ctx, fsys, subDir); err != nil {
+				return err
+			}
+			continue
+		}
+
+		base := entry.Name()
+		ext := filepath.Ext(base)
+		if ext != icloudMetadataExt {
+			continue
+		}
+
+		name := dir + "/" + base
+		if dir == "." {
+			name = base
+		}
+
+		// Only parse Photo Details CSVs for date extraction
+		if strings.HasPrefix(strings.ToLower(base), "photo details") {
+			err := UseICloudPhotoDetails(ifc.icloudMetas, fsys, name, ifc.addMonth)
+			if err != nil {
+				ifc.app.Log().Warn("PreScan: error parsing iCloud CSV", "file", name, "error", err.Error())
+			}
+		}
+	}
+	return nil
 }
 
 // preScanDir walks a directory to extract dates from filenames for pre-scan.

--- a/adapters/folder/icloud.go
+++ b/adapters/folder/icloud.go
@@ -17,6 +17,10 @@ type iCloudMeta struct {
 	originalCreationDate time.Time
 }
 
+// DateCollector is a callback invoked for each date parsed during iCloud CSV processing.
+// Callers can use this to track min/max dates or collect active months.
+type DateCollector func(t time.Time)
+
 func UseICloudMemory(m *gen.SyncMap[string, iCloudMeta], fsys fs.FS, filename string) (string, error) {
 	file, err := fsys.Open(filename)
 	if err != nil {
@@ -66,7 +70,7 @@ func useAlbum(m *gen.SyncMap[string, iCloudMeta], file fs.File, albumName string
 // Example:
 // imgName,fileChecksum,favorite,hidden,deleted,originalCreationDate,viewCount,importDate
 // IMG_7938.HEIC,AfQj57ORF2JIumUCjO+PawZ9nqPg,no,no,no,"Saturday June 4,2022 12:11 PM GMT",10,"Saturday June 4,2022 12:11 PM GMT"
-func UseICloudPhotoDetails(m *gen.SyncMap[string, iCloudMeta], fsys fs.FS, filename string) error {
+func UseICloudPhotoDetails(m *gen.SyncMap[string, iCloudMeta], fsys fs.FS, filename string, collectors ...DateCollector) error {
 	file, err := fsys.Open(filename)
 	if err != nil {
 		return err
@@ -98,6 +102,11 @@ func UseICloudPhotoDetails(m *gen.SyncMap[string, iCloudMeta], fsys fs.FS, filen
 		meta, _ := m.Load(fileName)
 		meta.originalCreationDate = t
 		m.Store(fileName, meta)
+
+		// Notify collectors of parsed date
+		for _, collect := range collectors {
+			collect(t)
+		}
 	}
 
 	return nil

--- a/adapters/folder/icloud.go
+++ b/adapters/folder/icloud.go
@@ -5,12 +5,19 @@ import (
 	"errors"
 	"io/fs"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
 	"github.com/simulot/immich-go/internal/assets"
 	"github.com/simulot/immich-go/internal/gen"
 )
+
+// icloudCSVSuffixPattern matches trailing digits appended directly to a word
+// character (letter/underscore) — this is how iCloud splits large CSVs into chunks
+// (e.g., "Trip1", "Trip10"). Names where digits follow a space or punctuation
+// (e.g., "Summer 2022", "Part 3") are NOT modified.
+var icloudCSVSuffixPattern = regexp.MustCompile(`^(.*[a-zA-Z_])\d+$`)
 
 type iCloudMeta struct {
 	albums               []assets.Album
@@ -27,7 +34,8 @@ func UseICloudMemory(m *gen.SyncMap[string, iCloudMeta], fsys fs.FS, filename st
 		return "", err
 	}
 	defer file.Close()
-	albumName := "Memory " + strings.TrimSuffix(filepath.Base(filename), filepath.Ext(filename))
+	baseName := strings.TrimSuffix(filepath.Base(filename), filepath.Ext(filename))
+	albumName := "Memory " + stripICloudCSVSuffix(baseName)
 
 	return albumName, useAlbum(m, file, albumName)
 }
@@ -38,9 +46,21 @@ func UseICloudAlbum(m *gen.SyncMap[string, iCloudMeta], fsys fs.FS, filename str
 		return "", err
 	}
 	defer file.Close()
-	albumName := strings.TrimSuffix(filepath.Base(filename), filepath.Ext(filename))
+	baseName := strings.TrimSuffix(filepath.Base(filename), filepath.Ext(filename))
+	albumName := stripICloudCSVSuffix(baseName)
 
 	return albumName, useAlbum(m, file, albumName)
+}
+
+// stripICloudCSVSuffix removes trailing digits that iCloud appends when splitting
+// large Memory/Album CSVs into chunks (e.g., "Trip1.csv", "Trip10.csv" are chunks
+// of "Trip.csv"). Uses greedy matching so "Summer 2022" stays as "Summer 2022"
+// (the digit must follow a non-digit character to be considered a suffix).
+func stripICloudCSVSuffix(name string) string {
+	if m := icloudCSVSuffixPattern.FindStringSubmatch(name); m != nil {
+		return m[1]
+	}
+	return name
 }
 
 func useAlbum(m *gen.SyncMap[string, iCloudMeta], file fs.File, albumName string) error {
@@ -60,8 +80,18 @@ func useAlbum(m *gen.SyncMap[string, iCloudMeta], file fs.File, albumName string
 		}
 		fileName := record[0]
 		meta, _ := m.Load(fileName)
-		meta.albums = append(meta.albums, assets.Album{Title: albumName})
-		m.Store(fileName, meta)
+		// Deduplicate: only add the album if this file doesn't already have it
+		hasAlbum := false
+		for _, a := range meta.albums {
+			if a.Title == albumName {
+				hasAlbum = true
+				break
+			}
+		}
+		if !hasAlbum {
+			meta.albums = append(meta.albums, assets.Album{Title: albumName})
+			m.Store(fileName, meta)
+		}
 	}
 
 	return nil
@@ -95,6 +125,10 @@ func UseICloudPhotoDetails(m *gen.SyncMap[string, iCloudMeta], fsys fs.FS, filen
 		}
 		fileName := record[0]
 		originalCreationDate := record[5]
+		if originalCreationDate == "" || originalCreationDate == "null" {
+			// Skip records with missing dates (deleted photos, etc.)
+			continue
+		}
 		t, err := time.Parse("Monday January 2,2006 15:04 PM GMT", originalCreationDate)
 		if err != nil {
 			return errors.Join(err, errors.New("invalid original creation date"))

--- a/adapters/folder/prescan_test.go
+++ b/adapters/folder/prescan_test.go
@@ -1,0 +1,333 @@
+package folder
+
+import (
+	"context"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/simulot/immich-go/internal/filenames"
+	"github.com/simulot/immich-go/internal/filetypes"
+	"github.com/simulot/immich-go/internal/gen"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddMonth(t *testing.T) {
+	tests := []struct {
+		name           string
+		dates          []time.Time
+		expectedMonths []string
+	}{
+		{
+			name:           "single date",
+			dates:          []time.Time{time.Date(2022, 6, 4, 12, 0, 0, 0, time.UTC)},
+			expectedMonths: []string{"2022-06"},
+		},
+		{
+			name: "multiple dates same month are deduplicated",
+			dates: []time.Time{
+				time.Date(2022, 6, 1, 0, 0, 0, 0, time.UTC),
+				time.Date(2022, 6, 15, 0, 0, 0, 0, time.UTC),
+				time.Date(2022, 6, 30, 0, 0, 0, 0, time.UTC),
+			},
+			expectedMonths: []string{"2022-06"},
+		},
+		{
+			name: "multiple months sorted",
+			dates: []time.Time{
+				time.Date(2023, 12, 1, 0, 0, 0, 0, time.UTC),
+				time.Date(2020, 1, 15, 0, 0, 0, 0, time.UTC),
+				time.Date(2022, 6, 4, 0, 0, 0, 0, time.UTC),
+			},
+			expectedMonths: []string{"2020-01", "2022-06", "2023-12"},
+		},
+		{
+			name:           "zero time is ignored",
+			dates:          []time.Time{time.Time{}, time.Date(2022, 6, 4, 0, 0, 0, 0, time.UTC)},
+			expectedMonths: []string{"2022-06"},
+		},
+		{
+			name:           "all zero times produce empty list",
+			dates:          []time.Time{time.Time{}, time.Time{}},
+			expectedMonths: []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ifc := &ImportFolderCmd{
+				activeMonthSet: make(map[string]struct{}),
+			}
+			for _, d := range tc.dates {
+				ifc.addMonth(d)
+			}
+			ifc.buildSortedMonths()
+			assert.Equal(t, tc.expectedMonths, ifc.ActiveMonths())
+		})
+	}
+}
+
+func TestAddMonth_Concurrent(t *testing.T) {
+	ifc := &ImportFolderCmd{
+		activeMonthSet: make(map[string]struct{}),
+	}
+
+	done := make(chan struct{})
+	for i := 0; i < 100; i++ {
+		go func(month int) {
+			defer func() { done <- struct{}{} }()
+			d := time.Date(2020, time.Month((month%12)+1), 1, 0, 0, 0, 0, time.UTC)
+			ifc.addMonth(d)
+		}(i)
+	}
+	for i := 0; i < 100; i++ {
+		<-done
+	}
+	ifc.buildSortedMonths()
+	months := ifc.ActiveMonths()
+	// Should have exactly 12 unique months
+	assert.Len(t, months, 12)
+	assert.Equal(t, "2020-01", months[0])
+	assert.Equal(t, "2020-12", months[11])
+}
+
+func TestICloudPhotoDetailsCollectsMonths(t *testing.T) {
+	// Create a temporary directory with a Photo Details.csv file
+	dir := t.TempDir()
+	csvContent := `imgName,fileChecksum,favorite,hidden,deleted,originalCreationDate,viewCount,importDate
+IMG_001.HEIC,abc123,no,no,no,"Saturday June 4,2022 12:11 PM GMT",10,"Saturday June 4,2022 12:11 PM GMT"
+IMG_002.HEIC,def456,no,no,no,"Monday January 15,2024 09:30 AM GMT",5,"Monday January 15,2024 09:30 AM GMT"
+IMG_003.HEIC,ghi789,no,no,no,"Saturday June 18,2022 14:00 PM GMT",3,"Saturday June 18,2022 14:00 PM GMT"
+`
+	csvPath := filepath.Join(dir, "Photo Details.csv")
+	err := os.WriteFile(csvPath, []byte(csvContent), 0o644)
+	require.NoError(t, err)
+
+	m := gen.NewSyncMap[string, iCloudMeta]()
+	fsys := os.DirFS(dir)
+
+	// Track months via DateCollector
+	ifc := &ImportFolderCmd{
+		activeMonthSet: make(map[string]struct{}),
+	}
+
+	err = UseICloudPhotoDetails(m, fsys, "Photo Details.csv", ifc.addMonth)
+	require.NoError(t, err)
+
+	ifc.buildSortedMonths()
+	months := ifc.ActiveMonths()
+
+	// Should have 2 unique months: 2022-06 and 2024-01
+	assert.Equal(t, []string{"2022-06", "2024-01"}, months)
+
+	// Verify the metas were also stored correctly
+	meta, ok := m.Load("IMG_001.HEIC")
+	assert.True(t, ok)
+	assert.Equal(t, 2022, meta.originalCreationDate.Year())
+	assert.Equal(t, time.June, meta.originalCreationDate.Month())
+
+	meta, ok = m.Load("IMG_002.HEIC")
+	assert.True(t, ok)
+	assert.Equal(t, 2024, meta.originalCreationDate.Year())
+	assert.Equal(t, time.January, meta.originalCreationDate.Month())
+}
+
+func TestICloudPhotoDetailsEmptyCSV(t *testing.T) {
+	dir := t.TempDir()
+	csvPath := filepath.Join(dir, "Photo Details.csv")
+	err := os.WriteFile(csvPath, []byte(""), 0o644)
+	require.NoError(t, err)
+
+	m := gen.NewSyncMap[string, iCloudMeta]()
+	fsys := os.DirFS(dir)
+
+	ifc := &ImportFolderCmd{
+		activeMonthSet: make(map[string]struct{}),
+	}
+
+	err = UseICloudPhotoDetails(m, fsys, "Photo Details.csv", ifc.addMonth)
+	require.NoError(t, err)
+
+	ifc.buildSortedMonths()
+	assert.Empty(t, ifc.ActiveMonths())
+}
+
+func TestPreScanWithFilenames(t *testing.T) {
+	// Create a temp directory structure with files that have date-bearing names
+	dir := t.TempDir()
+
+	// Create files with date patterns in their names
+	files := map[string]string{
+		"IMG_20220604_121100.jpg": "",
+		"IMG_20240115_093000.heic": "",
+		"IMG_20220604_140000.mp4":  "",
+		"no_date_file.jpg":         "",
+	}
+	for name, content := range files {
+		err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644)
+		require.NoError(t, err)
+	}
+
+	tz := time.UTC
+	sm := filetypes.DefaultSupportedMedia
+
+	ifc := &ImportFolderCmd{
+		Recursive:      true,
+		tz:             tz,
+		supportedMedia: sm,
+		infoCollector:  filenames.NewInfoCollector(tz, sm),
+		fsyss:          []fs.FS{os.DirFS(dir)},
+		activeMonthSet: make(map[string]struct{}),
+	}
+
+	months, err := ifc.PreScan(context.Background())
+	require.NoError(t, err)
+
+	// Should find months from the filename dates
+	// IMG_20220604 -> 2022-06
+	// IMG_20240115 -> 2024-01
+	// no_date_file.jpg -> falls back to file mod time (which is now)
+	assert.Contains(t, months, "2022-06")
+	assert.Contains(t, months, "2024-01")
+	// At least 2 date-bearing months, possibly more from mod times
+	assert.GreaterOrEqual(t, len(months), 2)
+}
+
+func TestPreScanWithICloudMetas(t *testing.T) {
+	// Create a temp directory with some files
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, "no_date.jpg"), []byte(""), 0o644)
+	require.NoError(t, err)
+
+	tz := time.UTC
+	sm := filetypes.DefaultSupportedMedia
+
+	// Pre-populate iCloud metas
+	metas := gen.NewSyncMap[string, iCloudMeta]()
+	metas.Store("photo1.heic", iCloudMeta{
+		originalCreationDate: time.Date(2019, 3, 15, 10, 0, 0, 0, time.UTC),
+	})
+	metas.Store("photo2.heic", iCloudMeta{
+		originalCreationDate: time.Date(2021, 11, 20, 14, 0, 0, 0, time.UTC),
+	})
+
+	ifc := &ImportFolderCmd{
+		Recursive:      true,
+		ICloudTakeout:  true,
+		tz:             tz,
+		supportedMedia: sm,
+		infoCollector:  filenames.NewInfoCollector(tz, sm),
+		fsyss:          []fs.FS{os.DirFS(dir)},
+		icloudMetas:    metas,
+		activeMonthSet: make(map[string]struct{}),
+	}
+
+	months, err := ifc.PreScan(context.Background())
+	require.NoError(t, err)
+
+	// Should contain months from iCloud metas
+	assert.Contains(t, months, "2019-03")
+	assert.Contains(t, months, "2021-11")
+}
+
+func TestPreScanNoDateTracking(t *testing.T) {
+	// Create a temp directory with a file that has no date in its name
+	dir := t.TempDir()
+
+	// Create a file with no date pattern and a very old mod time
+	filePath := filepath.Join(dir, "random.jpg")
+	err := os.WriteFile(filePath, []byte("fake image"), 0o644)
+	require.NoError(t, err)
+
+	tz := time.UTC
+	sm := filetypes.DefaultSupportedMedia
+
+	ifc := &ImportFolderCmd{
+		Recursive:      true,
+		tz:             tz,
+		supportedMedia: sm,
+		infoCollector:  filenames.NewInfoCollector(tz, sm),
+		fsyss:          []fs.FS{os.DirFS(dir)},
+		activeMonthSet: make(map[string]struct{}),
+	}
+
+	_, err = ifc.PreScan(context.Background())
+	require.NoError(t, err)
+
+	// The file has no date in its name, but it has a mod time (the time of creation during test).
+	// So it should still get a month from the mod time fallback.
+	// hasNoDateFiles should be false because mod time was available.
+	assert.False(t, ifc.HasNoDateFiles())
+	assert.GreaterOrEqual(t, len(ifc.ActiveMonths()), 1)
+}
+
+func TestPreScanRecursive(t *testing.T) {
+	// Create nested directory structure
+	dir := t.TempDir()
+	subDir := filepath.Join(dir, "2022", "vacation")
+	err := os.MkdirAll(subDir, 0o755)
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(dir, "IMG_20200101_120000.jpg"), []byte(""), 0o644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(subDir, "IMG_20220815_180000.heic"), []byte(""), 0o644)
+	require.NoError(t, err)
+
+	tz := time.UTC
+	sm := filetypes.DefaultSupportedMedia
+
+	ifc := &ImportFolderCmd{
+		Recursive:      true,
+		tz:             tz,
+		supportedMedia: sm,
+		infoCollector:  filenames.NewInfoCollector(tz, sm),
+		fsyss:          []fs.FS{os.DirFS(dir)},
+		activeMonthSet: make(map[string]struct{}),
+	}
+
+	months, err := ifc.PreScan(context.Background())
+	require.NoError(t, err)
+
+	assert.Contains(t, months, "2020-01")
+	assert.Contains(t, months, "2022-08")
+}
+
+func TestSetNoDateFiles(t *testing.T) {
+	ifc := &ImportFolderCmd{}
+
+	assert.False(t, ifc.HasNoDateFiles())
+
+	ifc.setNoDateFiles()
+	assert.True(t, ifc.HasNoDateFiles())
+
+	// Calling again is idempotent
+	ifc.setNoDateFiles()
+	assert.True(t, ifc.HasNoDateFiles())
+}
+
+func TestPreScanContextCancellation(t *testing.T) {
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, "IMG_20220604_121100.jpg"), []byte(""), 0o644)
+	require.NoError(t, err)
+
+	tz := time.UTC
+	sm := filetypes.DefaultSupportedMedia
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	ifc := &ImportFolderCmd{
+		Recursive:      true,
+		tz:             tz,
+		supportedMedia: sm,
+		infoCollector:  filenames.NewInfoCollector(tz, sm),
+		fsyss:          []fs.FS{os.DirFS(dir)},
+		activeMonthSet: make(map[string]struct{}),
+	}
+
+	_, err = ifc.PreScan(ctx)
+	assert.ErrorIs(t, err, context.Canceled)
+}

--- a/adapters/folder/run.go
+++ b/adapters/folder/run.go
@@ -103,9 +103,16 @@ const icloudMetadataExt = ".csv"
 
 func (ifc *ImportFolderCmd) Browse(ctx context.Context) chan *assets.Group {
 	gOut := make(chan *assets.Group)
+
+	// Recreate the worker pool for each Browse call (needed for multi-month batching)
+	if ifc.app != nil {
+		ifc.pool = worker.NewPool(ifc.app.ConcurrentTask)
+	}
+
 	go func() {
 		defer func() {
 			close(gOut)
+			ifc.targetMonth = "" // reset month filter after browsing
 		}()
 		// two passes for icloud takouts
 		if ifc.icloudMetaPass {
@@ -138,70 +145,28 @@ func (ifc *ImportFolderCmd) Browse(ctx context.Context) chan *assets.Group {
 // within the target month. The month parameter is a "YYYY-MM" string or
 // the special value "no-date" for assets with no determinable date.
 //
-// Date resolution order: CaptureDate > FileDate > NameInfo.Taken.
-// Files with no date at all are only included when month == "no-date".
+// Instead of post-filtering Browse() output (which extracts every file),
+// this sets a pre-filter so parseDir skips non-matching files before
+// extracting them from zip archives.
 func (ifc *ImportFolderCmd) BrowseMonth(ctx context.Context, month string) chan *assets.Group {
-	// Use Browse to get all groups, then filter assets per group.
-	allGroups := ifc.Browse(ctx)
-	gOut := make(chan *assets.Group)
-
-	go func() {
-		defer close(gOut)
-
-		isNoDate := month == "no-date"
-		var after, before time.Time
-		if !isNoDate {
-			var err error
-			after, before, err = adapters.MonthToDateRange(month)
-			if err != nil {
-				return
-			}
+	// Set the target month filter — parseDir will check this before extraction
+	ifc.targetMonth = month
+	if month != "no-date" {
+		after, before, err := adapters.MonthToDateRange(month)
+		if err != nil {
+			ch := make(chan *assets.Group)
+			close(ch)
+			return ch
 		}
+		ifc.targetAfter = after
+		ifc.targetBefore = before
+	} else {
+		ifc.targetAfter = time.Time{}
+		ifc.targetBefore = time.Time{}
+	}
 
-		for g := range allGroups {
-			var filtered []*assets.Asset
-			for _, a := range g.Assets {
-				d := assetDate(a)
-				if d.IsZero() {
-					if isNoDate {
-						filtered = append(filtered, a)
-					} else {
-						a.Close()
-					}
-				} else {
-					if isNoDate {
-						a.Close()
-					} else if (d.Equal(after) || d.After(after)) && d.Before(before) {
-						filtered = append(filtered, a)
-					} else {
-						a.Close()
-					}
-				}
-			}
-			if len(filtered) == 0 {
-				continue
-			}
-			fg := assets.NewGroup(g.Grouping, filtered...)
-			// Adjust cover index: if original cover is still present, keep it
-			coverIdx := 0
-			if g.CoverIndex < len(g.Assets) {
-				origCover := g.Assets[g.CoverIndex]
-				for i, a := range filtered {
-					if a == origCover {
-						coverIdx = i
-						break
-					}
-				}
-			}
-			fg.CoverIndex = coverIdx
-			select {
-			case gOut <- fg:
-			case <-ctx.Done():
-				return
-			}
-		}
-	}()
-	return gOut
+	// Browse will now respect the targetMonth filter in parseDir
+	return ifc.Browse(ctx)
 }
 
 // assetDate returns the best available date for the asset, following the
@@ -214,6 +179,45 @@ func assetDate(a *assets.Asset) time.Time {
 		return a.FileDate
 	}
 	return a.Taken
+}
+
+// matchesTargetMonth checks if a file belongs to the target month using
+// metadata available BEFORE extraction (iCloud CSV dates, filename dates).
+// Returns true if the file matches or if we can't determine the date
+// (to avoid dropping files that might belong).
+func (ifc *ImportFolderCmd) matchesTargetMonth(fsName, name, base string) bool {
+	isNoDate := ifc.targetMonth == "no-date"
+
+	// Try iCloud metadata first (most reliable for iCloud archives)
+	if ifc.ICloudTakeout && ifc.icloudMetas != nil {
+		// iCloud metas are keyed by original filename (the base name without path)
+		if meta, ok := ifc.icloudMetas.Load(base); ok {
+			if !meta.originalCreationDate.IsZero() {
+				d := meta.originalCreationDate
+				if isNoDate {
+					return false // has a date, doesn't belong in no-date batch
+				}
+				return (d.Equal(ifc.targetAfter) || d.After(ifc.targetAfter)) && d.Before(ifc.targetBefore)
+			}
+		}
+	}
+
+	// Try filename-based date detection
+	n := name
+	if fsName != "" {
+		n = fsName + "/" + n
+	}
+	info := ifc.infoCollector.GetInfo(n)
+	if !info.Taken.IsZero() {
+		if isNoDate {
+			return false
+		}
+		return (info.Taken.Equal(ifc.targetAfter) || info.Taken.After(ifc.targetAfter)) && info.Taken.Before(ifc.targetBefore)
+	}
+
+	// Can't determine date without extraction — include in no-date batch,
+	// or include anyway (will be filtered post-extraction if wrong)
+	return isNoDate
 }
 
 func (ifc *ImportFolderCmd) concurrentParseDir(ctx context.Context, fsys fs.FS, dir string, gOut chan *assets.Group) {
@@ -357,6 +361,13 @@ func (ifc *ImportFolderCmd) parseDir(ctx context.Context, fsys fs.FS, dir string
 				ifc.processor.RecordAssetDiscardedImmediately(ctx, fshelper.FSName(fsys, name), info.Size(), fileevent.DiscardedFiltered, "extension excluded")
 			}
 			continue
+		}
+
+		// Early month filter: check date from metadata/filename BEFORE extracting from zip
+		if ifc.targetMonth != "" {
+			if !ifc.matchesTargetMonth(fsName, name, base) {
+				continue
+			}
 		}
 
 		select {

--- a/adapters/folder/run.go
+++ b/adapters/folder/run.go
@@ -151,7 +151,7 @@ func (ifc *ImportFolderCmd) Browse(ctx context.Context) chan *assets.Group {
 func (ifc *ImportFolderCmd) BrowseMonth(ctx context.Context, month string) chan *assets.Group {
 	// Set the target month filter — parseDir will check this before extraction
 	ifc.targetMonth = month
-	if month != "no-date" {
+	if month != adapters.MonthNoDate {
 		after, before, err := adapters.MonthToDateRange(month)
 		if err != nil {
 			ch := make(chan *assets.Group)
@@ -169,16 +169,9 @@ func (ifc *ImportFolderCmd) BrowseMonth(ctx context.Context, month string) chan 
 	return ifc.Browse(ctx)
 }
 
-// assetDate returns the best available date for the asset, following the
-// resolution order: CaptureDate, FileDate, NameInfo.Taken.
+// assetDate returns the best available date for the asset.
 func assetDate(a *assets.Asset) time.Time {
-	if !a.CaptureDate.IsZero() {
-		return a.CaptureDate
-	}
-	if !a.FileDate.IsZero() {
-		return a.FileDate
-	}
-	return a.Taken
+	return a.BestDate()
 }
 
 // matchesTargetMonth checks if a file belongs to the target month using
@@ -186,7 +179,7 @@ func assetDate(a *assets.Asset) time.Time {
 // Returns true if the file matches or if we can't determine the date
 // (to avoid dropping files that might belong).
 func (ifc *ImportFolderCmd) matchesTargetMonth(fsName, name, base string) bool {
-	isNoDate := ifc.targetMonth == "no-date"
+	isNoDate := ifc.targetMonth == adapters.MonthNoDate
 
 	// Try iCloud metadata first (most reliable for iCloud archives)
 	if ifc.ICloudTakeout && ifc.icloudMetas != nil {

--- a/adapters/folder/run.go
+++ b/adapters/folder/run.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/simulot/immich-go/adapters"
 	"github.com/simulot/immich-go/app"
@@ -113,6 +114,16 @@ func (ifc *ImportFolderCmd) Browse(ctx context.Context) chan *assets.Group {
 			}
 			ifc.wg.Wait()
 			ifc.icloudMetaPass = false
+
+			// Collect dates from iCloud metas after the first pass
+			if ifc.icloudMetas != nil {
+				ifc.icloudMetas.Range(func(_ string, meta iCloudMeta) bool {
+					if !meta.originalCreationDate.IsZero() {
+						ifc.addMonth(meta.originalCreationDate)
+					}
+					return true
+				})
+			}
 		}
 		for _, fsys := range ifc.fsyss {
 			ifc.concurrentParseDir(ctx, fsys, ".", gOut)
@@ -121,6 +132,88 @@ func (ifc *ImportFolderCmd) Browse(ctx context.Context) chan *assets.Group {
 		ifc.pool.Stop()
 	}()
 	return gOut
+}
+
+// BrowseMonth works like Browse but only yields assets whose date falls
+// within the target month. The month parameter is a "YYYY-MM" string or
+// the special value "no-date" for assets with no determinable date.
+//
+// Date resolution order: CaptureDate > FileDate > NameInfo.Taken.
+// Files with no date at all are only included when month == "no-date".
+func (ifc *ImportFolderCmd) BrowseMonth(ctx context.Context, month string) chan *assets.Group {
+	// Use Browse to get all groups, then filter assets per group.
+	allGroups := ifc.Browse(ctx)
+	gOut := make(chan *assets.Group)
+
+	go func() {
+		defer close(gOut)
+
+		isNoDate := month == "no-date"
+		var after, before time.Time
+		if !isNoDate {
+			var err error
+			after, before, err = adapters.MonthToDateRange(month)
+			if err != nil {
+				return
+			}
+		}
+
+		for g := range allGroups {
+			var filtered []*assets.Asset
+			for _, a := range g.Assets {
+				d := assetDate(a)
+				if d.IsZero() {
+					if isNoDate {
+						filtered = append(filtered, a)
+					} else {
+						a.Close()
+					}
+				} else {
+					if isNoDate {
+						a.Close()
+					} else if (d.Equal(after) || d.After(after)) && d.Before(before) {
+						filtered = append(filtered, a)
+					} else {
+						a.Close()
+					}
+				}
+			}
+			if len(filtered) == 0 {
+				continue
+			}
+			fg := assets.NewGroup(g.Grouping, filtered...)
+			// Adjust cover index: if original cover is still present, keep it
+			coverIdx := 0
+			if g.CoverIndex < len(g.Assets) {
+				origCover := g.Assets[g.CoverIndex]
+				for i, a := range filtered {
+					if a == origCover {
+						coverIdx = i
+						break
+					}
+				}
+			}
+			fg.CoverIndex = coverIdx
+			select {
+			case gOut <- fg:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return gOut
+}
+
+// assetDate returns the best available date for the asset, following the
+// resolution order: CaptureDate, FileDate, NameInfo.Taken.
+func assetDate(a *assets.Asset) time.Time {
+	if !a.CaptureDate.IsZero() {
+		return a.CaptureDate
+	}
+	if !a.FileDate.IsZero() {
+		return a.FileDate
+	}
+	return a.Taken
 }
 
 func (ifc *ImportFolderCmd) concurrentParseDir(ctx context.Context, fsys fs.FS, dir string, gOut chan *assets.Group) {
@@ -187,7 +280,7 @@ func (ifc *ImportFolderCmd) parseDir(ctx context.Context, fsys fs.FS, dir string
 			}
 			// iCloud photo details (csv). File name pattern: "Photo Details.csv"
 			if strings.HasPrefix(strings.ToLower(base), "photo details") {
-				err := UseICloudPhotoDetails(ifc.icloudMetas, fsys, name)
+				err := UseICloudPhotoDetails(ifc.icloudMetas, fsys, name, ifc.addMonth)
 				if err != nil {
 					ifc.processor.RecordNonAsset(ctx, fshelper.FSName(fsys, name), 0, fileevent.ErrorFileAccess, "error", err.Error())
 				} else {
@@ -283,6 +376,23 @@ func (ifc *ImportFolderCmd) parseDir(ctx context.Context, fsys fs.FS, dir string
 					code = fileevent.DiscoveredVideo
 				}
 				ifc.processor.RecordAssetDiscovered(ctx, a.File, int64(a.FileSize), code)
+
+				// Collect date for pre-scan month tracking
+				assetDate := a.Taken // from filename via NameInfo
+				if assetDate.IsZero() && ifc.ICloudTakeout && ifc.icloudMetas != nil {
+					if meta, ok := ifc.icloudMetas.Load(a.OriginalFileName); ok {
+						assetDate = meta.originalCreationDate
+					}
+				}
+				if assetDate.IsZero() {
+					assetDate = a.FileDate
+				}
+				if !assetDate.IsZero() {
+					ifc.addMonth(assetDate)
+				} else {
+					ifc.setNoDateFiles()
+				}
+
 				as = append(as, a)
 			}
 		}

--- a/adapters/fromimmich/browsemonth.go
+++ b/adapters/fromimmich/browsemonth.go
@@ -1,0 +1,132 @@
+package fromimmich
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	cliflags "github.com/simulot/immich-go/internal/cliFlags"
+
+	"github.com/simulot/immich-go/immich"
+	"github.com/simulot/immich-go/internal/assets"
+)
+
+// PreScan queries the source Immich server for all matching assets and returns
+// a sorted list of YYYY-MM strings representing months that have assets.
+// It uses a lightweight callback that only collects dates without fetching
+// full asset details.
+func (fic *FromImmichCmd) PreScan(ctx context.Context) ([]string, error) {
+	fic.MinimalRating = min(max(0, fic.MinimalRating), 5)
+
+	so := immich.SearchOptions()
+
+	if !fic.OnlyArchived && !fic.OnlyTrashed && !fic.OnlyFavorite {
+		so.All()
+	} else {
+		if fic.OnlyArchived {
+			so.WithOnlyArchived()
+		}
+		if fic.OnlyTrashed {
+			so.WithOnlyTrashed()
+		}
+		if fic.OnlyFavorite {
+			so.WithOnlyFavorite()
+		}
+	}
+
+	if fic.Make != "" {
+		so.WithOnlyMake(fic.Make)
+	}
+	if fic.Model != "" {
+		so.WithOnlyMake(fic.Model)
+	}
+	if fic.Country != "" {
+		so.WithOnlyCountry(fic.Country)
+	}
+	if fic.State != "" {
+		so.WithOnlyState(fic.State)
+	}
+	if fic.City != "" {
+		so.WithOnlyCity(fic.City)
+	}
+
+	if fic.OnlyNoAlbum {
+		so.WithNotInAlbum()
+	} else {
+		so.WithAlbums(fic.albumIDs...)
+	}
+
+	if fic.InclusionFlags.DateRange.IsSet() {
+		so.WithDateRange(fic.InclusionFlags.DateRange)
+	}
+
+	if fic.MinimalRating > 1 {
+		so.WithMinimalRate(fic.MinimalRating)
+	}
+
+	if len(fic.albumIDs) > 0 {
+		so.WithAlbums(fic.albumIDs...)
+	}
+
+	if len(fic.tagIDs) > 0 {
+		so.WithTags(fic.tagIDs...)
+	}
+
+	if len(fic.peopleIDs) > 0 {
+		so.WithPeople(fic.peopleIDs...)
+	}
+
+	monthSet := make(map[string]struct{})
+	err := fic.client.Immich.GetFilteredAssetsFn(ctx, so, func(a *immich.Asset) error {
+		if !fic.IncludePartners && a.OwnerID != fic.client.User.ID {
+			return nil
+		}
+		d := a.LocalDateTime.Time
+		if d.IsZero() {
+			d = a.FileCreatedAt.Time
+		}
+		if !d.IsZero() {
+			month := fmt.Sprintf("%04d-%02d", d.Year(), d.Month())
+			monthSet[month] = struct{}{}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	months := make([]string, 0, len(monthSet))
+	for m := range monthSet {
+		months = append(months, m)
+	}
+	sort.Strings(months)
+	return months, nil
+}
+
+// BrowseMonth yields only assets whose date falls within the target month.
+// It temporarily overrides the date range filter and delegates to Browse.
+func (fic *FromImmichCmd) BrowseMonth(ctx context.Context, month string) chan *assets.Group {
+	if month == "no-date" {
+		// Immich assets always have dates from the server, return empty channel
+		ch := make(chan *assets.Group)
+		close(ch)
+		return ch
+	}
+
+	// Save and override the date range using the month string (e.g. "2022-06")
+	savedRange := fic.InclusionFlags.DateRange
+	fic.InclusionFlags.DateRange = cliflags.InitDateRange(nil, month)
+
+	gOut := make(chan *assets.Group)
+	go func() {
+		defer func() {
+			close(gOut)
+			fic.InclusionFlags.DateRange = savedRange
+		}()
+		err := fic.getAssets(ctx, gOut)
+		if err != nil {
+			fic.app.ProcessError(err) //nolint:errcheck
+		}
+	}()
+	return gOut
+}

--- a/adapters/fromimmich/browsemonth.go
+++ b/adapters/fromimmich/browsemonth.go
@@ -2,13 +2,13 @@ package fromimmich
 
 import (
 	"context"
-	"fmt"
-	"sort"
 
+	"github.com/simulot/immich-go/adapters"
 	cliflags "github.com/simulot/immich-go/internal/cliFlags"
 
 	"github.com/simulot/immich-go/immich"
 	"github.com/simulot/immich-go/internal/assets"
+	"github.com/simulot/immich-go/internal/gen"
 )
 
 // PreScan queries the source Immich server for all matching assets and returns
@@ -86,7 +86,7 @@ func (fic *FromImmichCmd) PreScan(ctx context.Context) ([]string, error) {
 			d = a.FileCreatedAt.Time
 		}
 		if !d.IsZero() {
-			month := fmt.Sprintf("%04d-%02d", d.Year(), d.Month())
+			month := adapters.TimeToMonth(d)
 			monthSet[month] = struct{}{}
 		}
 		return nil
@@ -95,18 +95,13 @@ func (fic *FromImmichCmd) PreScan(ctx context.Context) ([]string, error) {
 		return nil, err
 	}
 
-	months := make([]string, 0, len(monthSet))
-	for m := range monthSet {
-		months = append(months, m)
-	}
-	sort.Strings(months)
-	return months, nil
+	return gen.MapKeysSorted(monthSet), nil
 }
 
 // BrowseMonth yields only assets whose date falls within the target month.
 // It temporarily overrides the date range filter and delegates to Browse.
 func (fic *FromImmichCmd) BrowseMonth(ctx context.Context, month string) chan *assets.Group {
-	if month == "no-date" {
+	if month == adapters.MonthNoDate {
 		// Immich assets always have dates from the server, return empty channel
 		ch := make(chan *assets.Group)
 		close(ch)

--- a/adapters/googlePhotos/browsemonth.go
+++ b/adapters/googlePhotos/browsemonth.go
@@ -2,7 +2,6 @@ package gp
 
 import (
 	"context"
-	"fmt"
 	"path"
 	"path/filepath"
 	"sort"
@@ -11,6 +10,7 @@ import (
 	"github.com/simulot/immich-go/adapters"
 	"github.com/simulot/immich-go/internal/assets"
 	"github.com/simulot/immich-go/internal/fileevent"
+	"github.com/simulot/immich-go/internal/gen"
 	"github.com/simulot/immich-go/internal/groups"
 )
 
@@ -34,18 +34,13 @@ func (toc *TakeoutCmd) PreScan(ctx context.Context) ([]string, error) {
 		for _, a := range cat.matchedFiles {
 			d := gpAssetDate(a)
 			if !d.IsZero() {
-				month := fmt.Sprintf("%04d-%02d", d.Year(), d.Month())
+				month := adapters.TimeToMonth(d)
 				monthSet[month] = struct{}{}
 			}
 		}
 	}
 
-	months := make([]string, 0, len(monthSet))
-	for m := range monthSet {
-		months = append(months, m)
-	}
-	sort.Strings(months)
-	return months, nil
+	return gen.MapKeysSorted(monthSet), nil
 }
 
 // BrowseMonth yields only assets whose date falls within the target month.
@@ -58,7 +53,7 @@ func (toc *TakeoutCmd) BrowseMonth(ctx context.Context, month string) chan *asse
 		return gOut
 	}
 
-	if month != "no-date" {
+	if month != adapters.MonthNoDate {
 		after, before, err := adapters.MonthToDateRange(month)
 		if err != nil {
 			close(gOut)
@@ -68,7 +63,7 @@ func (toc *TakeoutCmd) BrowseMonth(ctx context.Context, month string) chan *asse
 		toc.targetAfter = after
 		toc.targetBefore = before
 	} else {
-		toc.targetMonth = "no-date"
+		toc.targetMonth = adapters.MonthNoDate
 		toc.targetAfter = time.Time{}
 		toc.targetBefore = time.Time{}
 	}
@@ -115,7 +110,7 @@ func (toc *TakeoutCmd) passTwoForMonth(ctx context.Context, gOut chan *assets.Gr
 func (toc *TakeoutCmd) handleDirForMonth(ctx context.Context, dir string, gOut chan *assets.Group) error {
 	catalog := toc.catalogs[dir]
 	dirEntries := make([]*assets.Asset, 0, len(catalog.matchedFiles))
-	isNoDate := toc.targetMonth == "no-date"
+	isNoDate := toc.targetMonth == adapters.MonthNoDate
 
 	for name := range catalog.matchedFiles {
 		a := catalog.matchedFiles[name]
@@ -230,11 +225,5 @@ func (toc *TakeoutCmd) handleDirForMonth(ctx context.Context, dir string, gOut c
 
 // gpAssetDate returns the best available date for a Google Photos asset.
 func gpAssetDate(a *assets.Asset) time.Time {
-	if !a.CaptureDate.IsZero() {
-		return a.CaptureDate
-	}
-	if !a.FileDate.IsZero() {
-		return a.FileDate
-	}
-	return a.Taken
+	return a.BestDate()
 }

--- a/adapters/googlePhotos/browsemonth.go
+++ b/adapters/googlePhotos/browsemonth.go
@@ -1,0 +1,240 @@
+package gp
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/simulot/immich-go/adapters"
+	"github.com/simulot/immich-go/internal/assets"
+	"github.com/simulot/immich-go/internal/fileevent"
+	"github.com/simulot/immich-go/internal/groups"
+)
+
+// PreScan builds the full catalog (passOne + solvePuzzle) and returns a sorted
+// list of YYYY-MM strings representing months that have assets.
+func (toc *TakeoutCmd) PreScan(ctx context.Context) ([]string, error) {
+	// Build the catalog: scan all archives and solve the metadata puzzle
+	for _, w := range toc.fsyss {
+		if err := toc.passOneFsWalk(ctx, w); err != nil {
+			return nil, err
+		}
+	}
+	if err := toc.solvePuzzle(ctx); err != nil {
+		return nil, err
+	}
+	toc.catalogBuilt = true
+
+	// Collect dates from all matched files
+	monthSet := make(map[string]struct{})
+	for _, cat := range toc.catalogs {
+		for _, a := range cat.matchedFiles {
+			d := gpAssetDate(a)
+			if !d.IsZero() {
+				month := fmt.Sprintf("%04d-%02d", d.Year(), d.Month())
+				monthSet[month] = struct{}{}
+			}
+		}
+	}
+
+	months := make([]string, 0, len(monthSet))
+	for m := range monthSet {
+		months = append(months, m)
+	}
+	sort.Strings(months)
+	return months, nil
+}
+
+// BrowseMonth yields only assets whose date falls within the target month.
+// The catalog must have been built by PreScan first.
+func (toc *TakeoutCmd) BrowseMonth(ctx context.Context, month string) chan *assets.Group {
+	gOut := make(chan *assets.Group)
+
+	if !toc.catalogBuilt {
+		close(gOut)
+		return gOut
+	}
+
+	if month != "no-date" {
+		after, before, err := adapters.MonthToDateRange(month)
+		if err != nil {
+			close(gOut)
+			return gOut
+		}
+		toc.targetMonth = month
+		toc.targetAfter = after
+		toc.targetBefore = before
+	} else {
+		toc.targetMonth = "no-date"
+		toc.targetAfter = time.Time{}
+		toc.targetBefore = time.Time{}
+	}
+
+	// Reset fileTracker status so dedup works within this month only
+	toc.fileTracker.Range(func(k fileKeyTracker, v trackingInfo) bool {
+		v.status = 0
+		toc.fileTracker.Store(k, v)
+		return true
+	})
+
+	go func() {
+		defer func() {
+			close(gOut)
+			toc.targetMonth = ""
+		}()
+		_ = toc.passTwoForMonth(ctx, gOut)
+	}()
+	return gOut
+}
+
+// passTwoForMonth is like passTwo but filters assets by the target month.
+// Assets outside the month are skipped without being closed or discarded.
+func (toc *TakeoutCmd) passTwoForMonth(ctx context.Context, gOut chan *assets.Group) error {
+	dirs := sort.StringSlice(make([]string, 0, len(toc.catalogs)))
+	for d := range toc.catalogs {
+		dirs = append(dirs, d)
+	}
+	sort.Strings(dirs)
+
+	for _, dir := range dirs {
+		if len(toc.catalogs[dir].matchedFiles) > 0 {
+			err := toc.handleDirForMonth(ctx, dir, gOut)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// handleDirForMonth is like handleDir but adds month-based filtering.
+// Assets outside the target month are silently skipped.
+func (toc *TakeoutCmd) handleDirForMonth(ctx context.Context, dir string, gOut chan *assets.Group) error {
+	catalog := toc.catalogs[dir]
+	dirEntries := make([]*assets.Asset, 0, len(catalog.matchedFiles))
+	isNoDate := toc.targetMonth == "no-date"
+
+	for name := range catalog.matchedFiles {
+		a := catalog.matchedFiles[name]
+		key := fileKeyTracker{baseName: name, size: int64(a.FileSize)}
+		track, _ := toc.fileTracker.Load(key)
+		if track.status == fileevent.ProcessedUploadSuccess {
+			continue // already emitted in this month batch
+		}
+
+		// Month filter: skip assets outside target month (no close, no discard)
+		d := gpAssetDate(a)
+		if isNoDate {
+			if !d.IsZero() {
+				continue
+			}
+		} else if d.IsZero() || d.Before(toc.targetAfter) || !d.Before(toc.targetBefore) {
+			continue
+		}
+
+		// Apply other metadata filters (archive, partner, trashed, album)
+		if code := toc.filterOnMetadata(ctx, a); code != fileevent.Code(0) {
+			continue
+		}
+		dirEntries = append(dirEntries, a)
+	}
+
+	in := make(chan *assets.Asset)
+	go func() {
+		defer close(in)
+
+		sort.Slice(dirEntries, func(i, j int) bool {
+			radicalI := dirEntries[i].Radical
+			radicalJ := dirEntries[j].Radical
+			if radicalI != radicalJ {
+				return radicalI < radicalJ
+			}
+			return dirEntries[i].CaptureDate.Before(dirEntries[j].CaptureDate)
+		})
+
+		for _, a := range dirEntries {
+			if toc.CreateAlbums {
+				if toc.ImportIntoAlbum != "" {
+					a.Albums = []assets.Album{{Title: toc.ImportIntoAlbum}}
+				} else {
+					key := fileKeyTracker{baseName: filepath.Base(a.File.Name()), size: int64(a.FileSize)}
+					track, _ := toc.fileTracker.Load(key)
+					for _, p := range track.paths {
+						if album, ok := toc.albums[p]; ok {
+							title := album.Title
+							if title == "" {
+								if !toc.KeepUntitled {
+									continue
+								}
+								title = filepath.Base(p)
+							}
+							a.Albums = append(a.Albums, assets.Album{
+								Title:       title,
+								Description: album.Description,
+								Latitude:    album.Latitude,
+								Longitude:   album.Longitude,
+							})
+						}
+					}
+				}
+				if toc.PartnerSharedAlbum != "" && a.FromPartner {
+					a.Albums = append(a.Albums, assets.Album{Title: toc.PartnerSharedAlbum})
+				}
+				if a.FromApplication != nil {
+					a.FromApplication.Albums = a.Albums
+				}
+			}
+			if a.Latitude == 0 && a.Longitude == 0 {
+				for _, album := range a.Albums {
+					if album.Latitude != 0 || album.Longitude != 0 {
+						a.Latitude = album.Latitude
+						a.Longitude = album.Longitude
+						break
+					}
+				}
+			}
+			if toc.TakeoutTag {
+				a.AddTag(toc.TakeoutName)
+			}
+
+			select {
+			case in <- a:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	gs := groups.NewGrouperPipeline(ctx, toc.groupers...).PipeGrouper(ctx, in)
+	for g := range gs {
+		select {
+		case gOut <- g:
+			for _, a := range g.Assets {
+				key := fileKeyTracker{
+					baseName: path.Base(a.File.Name()),
+					size:     int64(a.FileSize),
+				}
+				track, _ := toc.fileTracker.Load(key)
+				track.status = fileevent.ProcessedUploadSuccess
+				toc.fileTracker.Store(key, track)
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return nil
+}
+
+// gpAssetDate returns the best available date for a Google Photos asset.
+func gpAssetDate(a *assets.Asset) time.Time {
+	if !a.CaptureDate.IsZero() {
+		return a.CaptureDate
+	}
+	if !a.FileDate.IsZero() {
+		return a.FileDate
+	}
+	return a.Taken
+}

--- a/adapters/googlePhotos/cmdFromGooglePhotos.go
+++ b/adapters/googlePhotos/cmdFromGooglePhotos.go
@@ -60,6 +60,12 @@ type TakeoutCmd struct {
 	fileTracker    *gen.SyncMap[fileKeyTracker, trackingInfo] // map[fileKeyTracker]trackingInfo // key is base name + file size,  value is list of file paths
 	groupers       []groups.Grouper
 	// filters        []filters.Filter
+
+	// Pre-scan state (for DateRangeProvider / batched upload)
+	catalogBuilt bool      // true after PreScan has built the catalog
+	targetMonth  string    // "YYYY-MM", "no-date", or "" (no filter)
+	targetAfter  time.Time // inclusive lower bound for month filter
+	targetBefore time.Time // exclusive upper bound for month filter
 }
 
 func (toc *TakeoutCmd) RegisterFlags(flags *pflag.FlagSet, cmd *cobra.Command) {

--- a/adapters/googlePhotos/cmdFromGooglePhotos.go
+++ b/adapters/googlePhotos/cmdFromGooglePhotos.go
@@ -63,7 +63,7 @@ type TakeoutCmd struct {
 
 	// Pre-scan state (for DateRangeProvider / batched upload)
 	catalogBuilt bool      // true after PreScan has built the catalog
-	targetMonth  string    // "YYYY-MM", "no-date", or "" (no filter)
+	targetMonth  string    // "YYYY-MM", adapters.MonthNoDate, or "" (no filter)
 	targetAfter  time.Time // inclusive lower bound for month filter
 	targetBefore time.Time // exclusive upper bound for month filter
 }

--- a/app/app.go
+++ b/app/app.go
@@ -99,6 +99,11 @@ func (app *Application) SetSupportedMedia(sm filetypes.SupportedMedia) {
 	app.sm = sm
 }
 
+// NumErrors returns the total number of errors recorded so far.
+func (app *Application) NumErrors() int64 {
+	return app.numErrors.Load()
+}
+
 func (app *Application) ProcessError(err error) error {
 	if err == nil {
 		return nil

--- a/app/app.go
+++ b/app/app.go
@@ -45,7 +45,7 @@ func (app *Application) RegisterFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&app.CfgFile, "config", "", "config file (default is ./immich-go.yaml)")
 	flags.BoolVar(&app.DryRun, "dry-run", false, "dry run")
 	flags.BoolVar(&app.SaveConfig, "save-config", false, "Save the configuration to immich-go.yaml")
-	flags.Var(&app.OnErrors, "on-errors", "What to do when an error occurs (stop, continue, accept N errors at max)")
+	flags.Var(&app.OnErrors, "on-errors", "What to do when an error occurs (stop|continue|retry|N)")
 	flags.IntVar(&app.ConcurrentTask, "concurrent-tasks", runtime.NumCPU(), "Number of concurrent tasks (1-20)")
 }
 
@@ -114,6 +114,9 @@ func (app *Application) ProcessError(err error) error {
 		app.Log().Error("Error", "err", err.Error())
 		return err
 	} else if app.OnErrors == cliflags.OnErrorsNeverStop {
+		app.Log().Error("Error", "err", err.Error())
+		return nil
+	} else if app.OnErrors == cliflags.OnErrorsRetry {
 		app.Log().Error("Error", "err", err.Error())
 		return nil
 	} else if nErr > int64(app.OnErrors) {

--- a/app/upload/noui.go
+++ b/app/upload/noui.go
@@ -26,6 +26,9 @@ func (uc *UpCmd) runNoUI(ctx context.Context, app *app.Application) error {
 	var maxImmich, currImmich int
 	spinner := []rune{' ', ' ', '.', ' ', ' '}
 	spinIdx := 0
+	var prevSize int64
+	var prevTime time.Time
+	var speedStr string
 
 	immichUpdate := func(value, total int) {
 		lock.Lock()
@@ -50,11 +53,26 @@ func (uc *UpCmd) runNoUI(ctx context.Context, app *app.Application) error {
 		}
 		lock.Unlock()
 
+		// Compute upload speed
+		now := time.Now()
+		if tracker := app.FileProcessor().Tracker(); tracker != nil {
+			currentSize := tracker.GetProcessedSize()
+			if !prevTime.IsZero() {
+				elapsed := now.Sub(prevTime).Seconds()
+				if elapsed > 0 {
+					bps := float64(currentSize-prevSize) / elapsed
+					speedStr = formatSpeedNoUI(bps)
+				}
+			}
+			prevSize = currentSize
+			prevTime = now
+		}
+
 		monthInfo := ""
 		if uc.currentMonth != "" {
 			monthInfo = fmt.Sprintf("Month: %s, ", uc.currentMonth)
 		}
-		return fmt.Sprintf("\rImmich read %d%%, %sAssets found: %d, Upload errors: %d, Uploaded %d %s", immichPct, monthInfo, app.FileProcessor().Logger().TotalAssets(), counts[fileevent.ErrorServerError], counts[fileevent.ProcessedUploadSuccess], string(spinner[spinIdx]))
+		return fmt.Sprintf("\rImmich read %d%%, %sAssets found: %d, Upload errors: %d, Uploaded %d, Speed: %s %s", immichPct, monthInfo, app.FileProcessor().Logger().TotalAssets(), counts[fileevent.ErrorServerError], counts[fileevent.ProcessedUploadSuccess], speedStr, string(spinner[spinIdx]))
 	}
 	uiGrp := errgroup.Group{}
 
@@ -132,4 +150,20 @@ func (uc *UpCmd) runNoUI(ctx context.Context, app *app.Application) error {
 		err = context.Cause(ctx)
 	}
 	return err
+}
+
+func formatSpeedNoUI(bytesPerSec float64) string {
+	if bytesPerSec < 1 {
+		return "—"
+	}
+	const unit = 1024
+	if bytesPerSec < unit {
+		return fmt.Sprintf("%.0f B/s", bytesPerSec)
+	}
+	div, exp := float64(unit), 0
+	for n := bytesPerSec / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB/s", bytesPerSec/div, "KMGTPE"[exp])
 }

--- a/app/upload/noui.go
+++ b/app/upload/noui.go
@@ -50,7 +50,11 @@ func (uc *UpCmd) runNoUI(ctx context.Context, app *app.Application) error {
 		}
 		lock.Unlock()
 
-		return fmt.Sprintf("\rImmich read %d%%, Assets found: %d, Upload errors: %d, Uploaded %d %s", immichPct, app.FileProcessor().Logger().TotalAssets(), counts[fileevent.ErrorServerError], counts[fileevent.ProcessedUploadSuccess], string(spinner[spinIdx]))
+		monthInfo := ""
+		if uc.currentMonth != "" {
+			monthInfo = fmt.Sprintf("Month: %s, ", uc.currentMonth)
+		}
+		return fmt.Sprintf("\rImmich read %d%%, %sAssets found: %d, Upload errors: %d, Uploaded %d %s", immichPct, monthInfo, app.FileProcessor().Logger().TotalAssets(), counts[fileevent.ErrorServerError], counts[fileevent.ProcessedUploadSuccess], string(spinner[spinIdx]))
 	}
 	uiGrp := errgroup.Group{}
 

--- a/app/upload/noui.go
+++ b/app/upload/noui.go
@@ -61,7 +61,7 @@ func (uc *UpCmd) runNoUI(ctx context.Context, app *app.Application) error {
 				elapsed := now.Sub(prevTime).Seconds()
 				if elapsed > 0 {
 					bps := float64(currentSize-prevSize) / elapsed
-					speedStr = formatSpeedNoUI(bps)
+					speedStr = formatSpeed(bps)
 				}
 			}
 			prevSize = currentSize
@@ -152,7 +152,8 @@ func (uc *UpCmd) runNoUI(ctx context.Context, app *app.Application) error {
 	return err
 }
 
-func formatSpeedNoUI(bytesPerSec float64) string {
+// formatSpeed formats bytes/sec as a human-readable speed string.
+func formatSpeed(bytesPerSec float64) string {
 	if bytesPerSec < 1 {
 		return "—"
 	}

--- a/app/upload/run.go
+++ b/app/upload/run.go
@@ -277,17 +277,42 @@ func (uc *UpCmd) uploadBatched(ctx context.Context, adapter adapters.Reader, drp
 
 	uc.app.Log().Info(fmt.Sprintf("Processing %d months (of %d remaining)", len(remaining), len(months)-len(uc.state.CompletedMonths)))
 
-	// 4. Process month by month
-	for _, month := range remaining {
-		select {
-		case <-ctx.Done():
-			return context.Cause(ctx)
-		default:
+	// 4. Build the month-loop function that will be called from within either UI or NoUI
+	uc.batchTotal = len(remaining)
+	monthLoop := func(ctx context.Context) error {
+		for i, month := range remaining {
+			select {
+			case <-ctx.Done():
+				return context.Cause(ctx)
+			default:
+			}
+			uc.batchCurrent = i + 1
+			err := uc.processMonth(ctx, adapter, drp, month)
+			if err != nil {
+				return err
+			}
 		}
-		err := uc.processMonth(ctx, adapter, drp, month)
+		return nil
+	}
+
+	// 5. Run with UI or NoUI
+	useUI := !uc.NoUI
+	if useUI {
+		_, err := tcell.NewScreen()
 		if err != nil {
-			return err
+			uc.app.Log().Warn("can't initialize the screen for the UI mode. Falling back to no-gui mode", "err", err)
+			fmt.Println("can't initialize the screen for the UI mode. Falling back to no-gui mode")
+			useUI = false
 		}
+	}
+
+	if useUI {
+		err = uc.runBatchedUI(ctx, monthLoop)
+	} else {
+		err = monthLoop(ctx)
+	}
+	if err != nil {
+		return err
 	}
 
 	// Print batch summary
@@ -396,7 +421,8 @@ func (uc *UpCmd) processMonth(ctx context.Context, adapter adapters.Reader, drp 
 
 // runMonthNoUI runs the parallel initialization and upload loop for a single month
 // in the batched upload flow. It fetches server assets scoped to the date range,
-// fetches albums, and then runs the upload loop.
+// fetches albums, and runs the upload loop — all in parallel to avoid deadlock
+// (BrowseMonth's channel must be drained concurrently with server asset fetching).
 func (uc *UpCmd) runMonthNoUI(ctx context.Context, dr *cliflags.DateRange, groupChan chan *assets.Group) error {
 	ctx, cancel := context.WithCancelCause(ctx)
 	defer cancel(nil)
@@ -420,13 +446,27 @@ func (uc *UpCmd) runMonthNoUI(ctx context.Context, dr *cliflags.DateRange, group
 		return uc.getImmichAlbums(ctx)
 	})
 
+	// uploadLoop must run in parallel so it drains groupChan while server
+	// assets are being fetched. uploadLoop already waits for immichAssetsReady
+	// before processing each asset.
+	var uploadErr error
+	processGrp.Go(func() error {
+		uploadErr = uc.uploadLoop(ctx, groupChan)
+		if uploadErr != nil {
+			cancel(uploadErr)
+		}
+		return uploadErr
+	})
+
 	err := processGrp.Wait()
 	if err != nil {
-		return context.Cause(ctx)
+		cause := context.Cause(ctx)
+		if cause != nil {
+			return cause
+		}
+		return err
 	}
-
-	err = uc.uploadLoop(ctx, groupChan)
-	return err
+	return nil
 }
 
 func (uc *UpCmd) getImmichAlbums(ctx context.Context) error {
@@ -660,6 +700,13 @@ func (uc *UpCmd) handleAsset(ctx context.Context, a *assets.Asset) error {
 		a.Close() // Close and clean resources linked to the local asset
 	}()
 
+	// Wait for server asset index to be ready before checking duplicates
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-uc.immichAssetsReady:
+	}
+
 	// In batched mode, check if this file was already uploaded in a previous run
 	if uc.state != nil {
 		source := ""
@@ -673,7 +720,6 @@ func (uc *UpCmd) handleAsset(ctx context.Context, a *assets.Asset) error {
 		}
 	}
 
-	// var status stri g
 	advice, err := uc.assetIndex.ShouldUpload(a, uc)
 	if err != nil {
 		return err

--- a/app/upload/run.go
+++ b/app/upload/run.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -14,6 +15,7 @@ import (
 	"github.com/simulot/immich-go/immich"
 	"github.com/simulot/immich-go/internal/assets"
 	"github.com/simulot/immich-go/internal/assets/cache"
+	"github.com/simulot/immich-go/internal/assettracker"
 	cliflags "github.com/simulot/immich-go/internal/cliFlags"
 	"github.com/simulot/immich-go/internal/fileevent"
 	"github.com/simulot/immich-go/internal/filters"
@@ -34,6 +36,11 @@ func (uc *UpCmd) saveAlbum(ctx context.Context, album assets.Album, ids []string
 		}
 		uc.app.Log().Info("created album", "album", album.Title, "assets", len(ids))
 		album.ID = r.ID
+
+		// Add newly created album to the cached data so subsequent months
+		// know it already exists and won't create duplicates.
+		uc.addAlbumToCache(r.ID, album.Title, album.Description, ids)
+
 		return album, nil
 	}
 	_, err := uc.client.Immich.AddAssetToAlbum(ctx, album.ID, ids)
@@ -42,7 +49,44 @@ func (uc *UpCmd) saveAlbum(ctx context.Context, album assets.Album, ids []string
 		return album, err
 	}
 	uc.app.Log().Info("updated album", "album", album.Title, "assets", len(ids))
+
+	// Update cached album data with newly added asset IDs
+	uc.appendAssetsToCachedAlbum(album.ID, ids)
+
 	return album, err
+}
+
+// addAlbumToCache appends a newly created album to cachedAlbums so that
+// subsequent months' getImmichAlbums merge will find it (avoiding duplicate creation).
+func (uc *UpCmd) addAlbumToCache(id, name, description string, assetIDs []string) {
+	albumAssets := make([]*immich.Asset, len(assetIDs))
+	for i, aid := range assetIDs {
+		albumAssets[i] = &immich.Asset{ID: aid}
+	}
+	uc.cachedAlbums = append(uc.cachedAlbums, albumResult{
+		album: immich.AlbumContent{
+			ID:          id,
+			AlbumName:   name,
+			Description: description,
+			Assets:      albumAssets,
+		},
+	})
+}
+
+// appendAssetsToCachedAlbum adds asset IDs to an existing album in cachedAlbums
+// so the next month's merge knows about them.
+func (uc *UpCmd) appendAssetsToCachedAlbum(albumID string, newIDs []string) {
+	for i := range uc.cachedAlbums {
+		if uc.cachedAlbums[i].err != nil {
+			continue
+		}
+		if uc.cachedAlbums[i].album.ID == albumID {
+			for _, id := range newIDs {
+				uc.cachedAlbums[i].album.Assets = append(uc.cachedAlbums[i].album.Assets, &immich.Asset{ID: id})
+			}
+			return
+		}
+	}
 }
 
 func (uc *UpCmd) saveTags(ctx context.Context, tag assets.Tag, ids []string) (assets.Tag, error) {
@@ -126,9 +170,34 @@ func (uc *UpCmd) finishing(ctx context.Context) error {
 				uc.app.Log().Info(s)
 			}
 		}
+
+		// Write error report file if there were errors
+		if tracker := uc.app.FileProcessor().Tracker(); tracker != nil {
+			errs := tracker.GetErrors()
+			if len(errs) > 0 {
+				uc.writeErrorReport(errs)
+			}
+		}
 	}
 
 	return nil
+}
+
+func (uc *UpCmd) writeErrorReport(errs []assettracker.AssetRecord) {
+	reportFile := fmt.Sprintf("immich-go-errors-%s.txt", time.Now().Format("2006-01-02T15-04-05"))
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("immich-go error report - %s\n", time.Now().Format("2006-01-02 15:04:05")))
+	sb.WriteString(fmt.Sprintf("Total errors: %d\n\n", len(errs)))
+	for _, e := range errs {
+		sb.WriteString(fmt.Sprintf("%-20s %s\n  Error: %s\n\n", e.EventCode, e.File.FullName(), e.Reason))
+	}
+
+	if err := os.WriteFile(reportFile, []byte(sb.String()), 0o644); err != nil {
+		uc.app.Log().Error("can't write error report", "file", reportFile, "err", err)
+		return
+	}
+	fmt.Printf("\nError report written to: %s\n", reportFile)
+	uc.app.Log().Info("Error report written", "file", reportFile, "errors", len(errs))
 }
 
 func (uc *UpCmd) upload(ctx context.Context, adapter adapters.Reader) error {
@@ -177,6 +246,7 @@ func (uc *UpCmd) uploadUnbatched(ctx context.Context, adapter adapters.Reader) e
 	runner := uc.runUI
 	uc.assetIndex = newAssetIndex()
 	uc.immichAssetsReady = make(chan struct{})
+	uc.immichAlbumsReady = make(chan struct{})
 
 	if uc.NoUI {
 		runner = uc.runNoUI
@@ -368,6 +438,7 @@ func (uc *UpCmd) processMonth(ctx context.Context, adapter adapters.Reader, drp 
 	// Fresh asset index per month (key for memory efficiency)
 	uc.assetIndex = newAssetIndex()
 	uc.immichAssetsReady = make(chan struct{})
+	uc.immichAlbumsReady = make(chan struct{})
 
 	// Set in-progress
 	uc.state.SetInProgressMonth(month)
@@ -478,50 +549,85 @@ func (uc *UpCmd) runMonthNoUI(ctx context.Context, dr *cliflags.DateRange, group
 	return nil
 }
 
-func (uc *UpCmd) getImmichAlbums(ctx context.Context) error {
-	// Get the album list from the server, but without assets.
+type albumResult struct {
+	album immich.AlbumContent
+	err   error
+}
+
+// fetchAlbumDetails fetches all album details from the server concurrently.
+// Results are cached on UpCmd so subsequent calls are a no-op.
+func (uc *UpCmd) fetchAlbumDetails(ctx context.Context) error {
+	if uc.albumsFetched {
+		return nil
+	}
+
 	serverAlbums, err := uc.client.Immich.GetAllAlbums(ctx)
 	if err != nil {
 		return fmt.Errorf("can't get the album list from the server: %w", err)
 	}
 
+	results := make([]albumResult, len(serverAlbums))
+	const maxConcurrent = 5
+	pool := worker.NewPool(min(maxConcurrent, max(1, len(serverAlbums))))
+	var wg sync.WaitGroup
+
+	for i, sa := range serverAlbums {
+		wg.Add(1)
+		i, sa := i, sa
+		pool.Submit(func() {
+			defer wg.Done()
+			r, err := uc.client.Immich.GetAlbumInfo(ctx, sa.ID, false)
+			results[i] = albumResult{album: r, err: err}
+		})
+	}
+	wg.Wait()
+	pool.Stop()
+
+	uc.cachedAlbums = results
+	uc.albumsFetched = true
+	uc.app.Log().Info(fmt.Sprintf("Fetched %d album details from server", len(results)))
+	return nil
+}
+
+// getImmichAlbums fetches album details (once) and merges them into the
+// current assetIndex and albumsCache. Safe to call multiple times — the
+// server fetch is cached, only the merge runs again.
+func (uc *UpCmd) getImmichAlbums(ctx context.Context) error {
+	if err := uc.fetchAlbumDetails(ctx); err != nil {
+		return err
+	}
+
+	// Wait for asset index to be ready before merging
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
 	case <-uc.immichAssetsReady:
-		// Wait for the server's assets to be ready.
-		for _, a := range serverAlbums {
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			default:
-				// Get the album info from the server, with assets.
-				r, err := uc.client.Immich.GetAlbumInfo(ctx, a.ID, false)
-				if err != nil {
-					uc.app.Log().Error("can't get the album info from the server", "album", a.AlbumName, "err", err)
-					continue
-				}
-				ids := make([]string, 0, len(r.Assets))
-				for _, aa := range r.Assets {
-					ids = append(ids, aa.ID)
-				}
+	}
 
-				album := assets.NewAlbum(a.ID, a.AlbumName, a.Description)
-				uc.albumsCache.NewCollection(a.AlbumName, album, ids)
-				uc.app.Log().Info("got album from the server", "album", a.AlbumName, "assets", len(r.Assets))
-				uc.app.Log().Debug("got album from the server", "album", a.AlbumName, "assets", ids)
-				// assign the album to the assets
-				for _, id := range ids {
-					a := uc.assetIndex.getByID(id)
-					if a == nil {
-						uc.app.Log().Debug("processing the immich albums: asset not found in index", "id", id)
-						continue
-					}
-					a.Albums = append(a.Albums, album)
-				}
+	// Merge cached results into the current asset index
+	for _, res := range uc.cachedAlbums {
+		if res.err != nil {
+			continue
+		}
+		r := res.album
+		ids := make([]string, 0, len(r.Assets))
+		for _, aa := range r.Assets {
+			ids = append(ids, aa.ID)
+		}
+
+		album := assets.NewAlbum(r.ID, r.AlbumName, r.Description)
+		uc.albumsCache.NewCollection(r.AlbumName, album, ids)
+		for _, id := range ids {
+			a := uc.assetIndex.getByID(id)
+			if a == nil {
+				continue
 			}
+			a.Albums = append(a.Albums, album)
 		}
 	}
+
+	// Signal that albums are ready for use by uploadLoop
+	close(uc.immichAlbumsReady)
 	return nil
 }
 
@@ -966,6 +1072,15 @@ func (uc *UpCmd) replaceAsset(ctx context.Context, newAsset, oldAsset *assets.As
 func (uc *UpCmd) manageAssetAlbums(ctx context.Context, f fshelper.FSAndName, ID string, albums []assets.Album) {
 	if len(albums) == 0 {
 		return
+	}
+
+	// Wait for server albums to be merged into albumsCache before adding
+	// assets. Without this, we'd create new albums instead of reusing
+	// existing ones from the server.
+	select {
+	case <-ctx.Done():
+		return
+	case <-uc.immichAlbumsReady:
 	}
 
 	for _, album := range albums {

--- a/app/upload/run.go
+++ b/app/upload/run.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/simulot/immich-go/adapters"
@@ -260,10 +262,17 @@ func (uc *UpCmd) uploadBatched(ctx context.Context, adapter adapters.Reader, drp
 
 	// 3. Filter months: remove completed, apply batch-limit
 	var remaining []string
+	var skippedMonths []string
 	for _, m := range months {
-		if !uc.state.IsMonthCompleted(m) {
+		if uc.state.IsMonthCompleted(m) {
+			skippedMonths = append(skippedMonths, m)
+		} else {
 			remaining = append(remaining, m)
 		}
+	}
+
+	if len(skippedMonths) > 0 {
+		uc.app.Log().Info(fmt.Sprintf("Skipping %d already completed months: %s", len(skippedMonths), strings.Join(skippedMonths, ", ")))
 	}
 
 	if len(remaining) == 0 {
@@ -275,7 +284,7 @@ func (uc *UpCmd) uploadBatched(ctx context.Context, adapter adapters.Reader, drp
 		remaining = remaining[:uc.BatchLimit]
 	}
 
-	uc.app.Log().Info(fmt.Sprintf("Processing %d months (of %d remaining)", len(remaining), len(months)-len(uc.state.CompletedMonths)))
+	uc.app.Log().Info(fmt.Sprintf("Processing %d months (of %d remaining): %s", len(remaining), len(months)-len(skippedMonths), strings.Join(remaining, ", ")))
 
 	// 4. Build the month-loop function that will be called from within either UI or NoUI
 	uc.batchTotal = len(remaining)
@@ -608,7 +617,11 @@ func (uc *UpCmd) getImmichAssetsFiltered(ctx context.Context, dr cliflags.DateRa
 func (uc *UpCmd) uploadLoop(ctx context.Context, groupChan chan *assets.Group) error {
 	ctx, cancel := context.WithCancelCause(ctx)
 
-	// the goroutine submits the groups, and stops when then number of error is higher than tolerated
+	useAdaptive := uc.app.OnErrors == cliflags.OnErrorsRetry
+	throttle := worker.NewThrottle(uc.app.ConcurrentTask)
+
+	var consecutiveSuccesses atomic.Int64
+
 	var wg sync.WaitGroup
 	wg.Go(func() {
 		workers := worker.NewPool(uc.app.ConcurrentTask)
@@ -622,12 +635,45 @@ func (uc *UpCmd) uploadLoop(ctx context.Context, groupChan chan *assets.Group) e
 				if !ok {
 					return
 				}
+				if useAdaptive {
+					throttle.Acquire()
+				}
 				workers.Submit(func() {
+					if useAdaptive {
+						defer throttle.Release()
+					}
 					err := uc.handleGroup(ctx, g)
 					if err != nil {
+						if useAdaptive && immich.IsRetryable(err) {
+							consecutiveSuccesses.Store(0)
+							cur := throttle.Current()
+							newLevel := max(cur/2, 1)
+							if newLevel < cur {
+								throttle.SetConcurrency(newLevel)
+								uc.app.Log().Info("Reducing concurrency due to server errors", "from", cur, "to", newLevel)
+							}
+							// Brief pause to let server recover
+							select {
+							case <-time.After(5 * time.Second):
+							case <-ctx.Done():
+							}
+						}
 						err = uc.app.ProcessError(err)
 						if err != nil {
 							cancel(err)
+						}
+					} else {
+						if useAdaptive {
+							n := consecutiveSuccesses.Add(1)
+							if n%10 == 0 {
+								cur := throttle.Current()
+								maxLevel := throttle.Max()
+								if cur < maxLevel {
+									newLevel := min(cur+1, maxLevel)
+									throttle.SetConcurrency(newLevel)
+									uc.app.Log().Info("Increasing concurrency after consecutive successes", "from", cur, "to", newLevel)
+								}
+							}
 						}
 					}
 				})
@@ -715,7 +761,8 @@ func (uc *UpCmd) handleAsset(ctx context.Context, a *assets.Asset) error {
 		}
 		filePath := a.File.Name()
 		if uc.state.IsFileUploaded(source, filePath, int64(a.FileSize)) {
-			uc.app.Log().Debug("Skipping file already uploaded in previous run", "file", filePath)
+			uc.resumeSkipped.Add(1)
+			uc.app.Log().Info("Skipping file already uploaded in previous run", "file", filePath)
 			return nil
 		}
 	}

--- a/app/upload/run.go
+++ b/app/upload/run.go
@@ -473,6 +473,7 @@ func (uc *UpCmd) processMonth(ctx context.Context, adapter adapters.Reader, drp 
 
 	// Run the parallel initialization + upload using runMonthNoUI
 	// (always NoUI for batched mode to keep it simple and avoid UI flicker per month)
+	errsBefore := uc.app.NumErrors()
 	err := uc.runMonthNoUI(ctx, dr, groupChan)
 
 	// Clean up per-month resources
@@ -489,13 +490,23 @@ func (uc *UpCmd) processMonth(ctx context.Context, adapter adapters.Reader, drp 
 		return err
 	}
 
-	// Mark complete
-	uc.state.CompleteMonth(month)
-	if err := uc.state.SaveState(); err != nil {
-		uc.app.Log().Error("can't save state after completing month", "err", err)
+	// Only mark the month complete if no errors occurred during processing.
+	// In continue/retry mode, ProcessError swallows errors to keep going,
+	// but we must not mark the month done so that failed files are retried
+	// on the next run.
+	if uc.app.NumErrors() > errsBefore {
+		uc.app.Log().Warn(fmt.Sprintf("Month %s had errors, not marking as complete", month))
+		if err := uc.state.FlushState(); err != nil {
+			uc.app.Log().Error("can't save state", "err", err)
+		}
+	} else {
+		uc.state.CompleteMonth(month)
+		if err := uc.state.SaveState(); err != nil {
+			uc.app.Log().Error("can't save state after completing month", "err", err)
+		}
+		uc.app.Log().Info(fmt.Sprintf("Completed month: %s", month))
 	}
 
-	uc.app.Log().Info(fmt.Sprintf("Completed month: %s", month))
 	return nil
 }
 

--- a/app/upload/run.go
+++ b/app/upload/run.go
@@ -273,9 +273,9 @@ func (uc *UpCmd) uploadBatched(ctx context.Context, adapter adapters.Reader, drp
 	}
 	uc.app.Log().Info(fmt.Sprintf("Pre-scan found %d months", len(months)))
 
-	// Check if there are no-date files; if so, add a "no-date" batch at the end
+	// Check if there are no-date files; if so, add a no-date batch at the end
 	if provider, ok := adapter.(interface{ HasNoDateFiles() bool }); ok && provider.HasNoDateFiles() {
-		months = append(months, "no-date")
+		months = append(months, adapters.MonthNoDate)
 	}
 
 	// 2. Load state
@@ -463,7 +463,7 @@ func (uc *UpCmd) processMonth(ctx context.Context, adapter adapters.Reader, drp 
 
 	// Determine the asset fetch function for this month
 	var dr *cliflags.DateRange
-	if month != "no-date" {
+	if month != adapters.MonthNoDate {
 		after, before, err := adapters.MonthToDateRange(month)
 		if err != nil {
 			return fmt.Errorf("invalid month %q: %w", month, err)
@@ -676,7 +676,7 @@ func (uc *UpCmd) getImmichAssets(ctx context.Context, updateFn progressUpdate) e
 
 // getImmichAssetsFiltered fetches server assets scoped to a date range
 // (used in batched mode). If the date range is not set, it falls back
-// to GetAllAssets (used for the "no-date" batch).
+// to GetAllAssets (used for the no-date batch).
 func (uc *UpCmd) getImmichAssetsFiltered(ctx context.Context, dr cliflags.DateRange, updateFn progressUpdate) error {
 	defer close(uc.immichAssetsReady)
 	received := 0
@@ -820,7 +820,7 @@ func (uc *UpCmd) handleGroup(ctx context.Context, g *assets.Group) error {
 	// Upload assets from the group
 	for _, a := range g.Assets {
 		err := uc.handleAsset(ctx, a)
-		errGroup = errors.Join(err)
+		errGroup = errors.Join(errGroup, err)
 	}
 
 	// Manage groups
@@ -1018,9 +1018,10 @@ func (uc *UpCmd) uploadAsset(ctx context.Context, a *assets.Asset) (string, erro
 		if fs, ok := a.File.FS().(interface{ Name() string }); ok {
 			source = fs.Name()
 		}
-		uc.state.RecordFileUploaded(source, a.File.Name(), int64(a.FileSize))
-		if err := uc.state.SaveState(); err != nil {
-			uc.app.Log().Error("can't save state after upload", "err", err)
+		if shouldSave := uc.state.RecordFileUploaded(source, a.File.Name(), int64(a.FileSize)); shouldSave {
+			if err := uc.state.SaveState(); err != nil {
+				uc.app.Log().Error("can't save state after upload", "err", err)
+			}
 		}
 	}
 

--- a/app/upload/run.go
+++ b/app/upload/run.go
@@ -441,10 +441,10 @@ func (uc *UpCmd) runMonthNoUI(ctx context.Context, dr *cliflags.DateRange, group
 	processGrp.Go(func() error {
 		var err error
 		if dr != nil {
-			err = uc.getImmichAssetsFiltered(ctx, *dr, nil)
+			err = uc.getImmichAssetsFiltered(ctx, *dr, uc.immichUpdateFn)
 		} else {
 			// no-date batch: fetch all assets (or skip server fetch)
-			err = uc.getImmichAssetsFiltered(ctx, cliflags.DateRange{}, nil)
+			err = uc.getImmichAssetsFiltered(ctx, cliflags.DateRange{}, uc.immichUpdateFn)
 		}
 		if err != nil {
 			cancel(err)

--- a/app/upload/run.go
+++ b/app/upload/run.go
@@ -12,10 +12,12 @@ import (
 	"github.com/simulot/immich-go/immich"
 	"github.com/simulot/immich-go/internal/assets"
 	"github.com/simulot/immich-go/internal/assets/cache"
+	cliflags "github.com/simulot/immich-go/internal/cliFlags"
 	"github.com/simulot/immich-go/internal/fileevent"
 	"github.com/simulot/immich-go/internal/filters"
 	"github.com/simulot/immich-go/internal/fshelper"
 	"github.com/simulot/immich-go/internal/worker"
+	"golang.org/x/sync/errgroup"
 )
 
 func (uc *UpCmd) saveAlbum(ctx context.Context, album assets.Album, ids []string) (assets.Album, error) {
@@ -98,8 +100,14 @@ func (uc *UpCmd) finishing(ctx context.Context) error {
 	}
 	defer func() { uc.finished = true }()
 	// do waiting operations
-	uc.albumsCache.Close()
-	uc.tagsCache.Close()
+	if uc.albumsCache != nil {
+		uc.albumsCache.Close()
+		uc.albumsCache = nil
+	}
+	if uc.tagsCache != nil {
+		uc.tagsCache.Close()
+		uc.tagsCache = nil
+	}
 
 	// Resume immich background jobs if requested
 	err := uc.resumeJobs(ctx)
@@ -138,6 +146,25 @@ func (uc *UpCmd) upload(ctx context.Context, adapter adapters.Reader) error {
 			fmt.Println(uc.app.FileProcessor().GenerateReport())
 		}
 	}()
+
+	uc.adapter = adapter
+
+	// Check if adapter supports batched mode
+	drp, hasBatching := adapter.(adapters.DateRangeProvider)
+	if hasBatching {
+		return uc.uploadBatched(ctx, adapter, drp)
+	}
+
+	// Fall back to existing behavior (unchanged)
+	return uc.uploadUnbatched(ctx, adapter)
+}
+
+// uploadUnbatched is the original upload path: fetch all server assets, then upload everything.
+// Used when the adapter does not implement DateRangeProvider.
+func (uc *UpCmd) uploadUnbatched(ctx context.Context, adapter adapters.Reader) error {
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(nil)
+
 	uc.albumsCache = cache.NewCollectionCache(50, func(album assets.Album, ids []string) (assets.Album, error) {
 		return uc.saveAlbum(ctx, album, ids)
 	})
@@ -145,10 +172,9 @@ func (uc *UpCmd) upload(ctx context.Context, adapter adapters.Reader) error {
 		return uc.saveTags(ctx, tag, ids)
 	})
 
-	uc.adapter = adapter
-
 	runner := uc.runUI
 	uc.assetIndex = newAssetIndex()
+	uc.immichAssetsReady = make(chan struct{})
 
 	if uc.NoUI {
 		runner = uc.runNoUI
@@ -161,6 +187,245 @@ func (uc *UpCmd) upload(ctx context.Context, adapter adapters.Reader) error {
 		}
 	}
 	err := runner(ctx, uc.app)
+	return err
+}
+
+// uploadBatched processes uploads month by month, scoping server queries
+// to each month's date range for memory efficiency.
+func (uc *UpCmd) uploadBatched(ctx context.Context, adapter adapters.Reader, drp adapters.DateRangeProvider) error {
+	// 1. PreScan to get month list
+	uc.app.Log().Info("Pre-scanning to determine month list...")
+	months, err := drp.PreScan(ctx)
+	if err != nil {
+		return fmt.Errorf("pre-scan failed: %w", err)
+	}
+	uc.app.Log().Info(fmt.Sprintf("Pre-scan found %d months", len(months)))
+
+	// Check if there are no-date files; if so, add a "no-date" batch at the end
+	if provider, ok := adapter.(interface{ HasNoDateFiles() bool }); ok && provider.HasNoDateFiles() {
+		months = append(months, "no-date")
+	}
+
+	// 2. Load state
+	serverURL := uc.client.Server
+	archivePath := "" // derive from adapter if possible
+	if named, ok := adapter.(interface{ ArchivePath() string }); ok {
+		archivePath = named.ArchivePath()
+	}
+
+	stateDir := uc.StateDir
+	if stateDir == "" {
+		stateDir = DefaultStateDir(serverURL, archivePath)
+	}
+
+	uc.state, err = LoadState(stateDir, serverURL, archivePath)
+	if err != nil {
+		return fmt.Errorf("can't load state: %w", err)
+	}
+
+	if uc.ResetState {
+		uc.state.ResetState()
+		if err := uc.state.SaveState(); err != nil {
+			return fmt.Errorf("can't save reset state: %w", err)
+		}
+		fmt.Printf("State has been reset for %s -> %s\n", archivePath, serverURL)
+	}
+
+	if uc.ShowState {
+		completed := len(uc.state.CompletedMonths)
+		total := len(months)
+		remaining := 0
+		for _, m := range months {
+			if !uc.state.IsMonthCompleted(m) {
+				remaining++
+			}
+		}
+		nextMonth := ""
+		for _, m := range months {
+			if !uc.state.IsMonthCompleted(m) {
+				nextMonth = m
+				break
+			}
+		}
+		fmt.Printf("Upload state for %s -> %s\n", archivePath, serverURL)
+		fmt.Printf("  Total months: %d\n", total)
+		fmt.Printf("  Completed:    %d\n", completed)
+		fmt.Printf("  Remaining:    %d\n", remaining)
+		if nextMonth != "" {
+			fmt.Printf("  Next month:   %s\n", nextMonth)
+		}
+		fmt.Printf("  Last updated: %s\n", uc.state.UpdatedAt.Format("2006-01-02 15:04"))
+		return nil
+	}
+
+	// 3. Filter months: remove completed, apply batch-limit
+	var remaining []string
+	for _, m := range months {
+		if !uc.state.IsMonthCompleted(m) {
+			remaining = append(remaining, m)
+		}
+	}
+
+	if len(remaining) == 0 {
+		uc.app.Log().Info("All months already completed. Nothing to do.")
+		return nil
+	}
+
+	if uc.BatchLimit > 0 && len(remaining) > uc.BatchLimit {
+		remaining = remaining[:uc.BatchLimit]
+	}
+
+	uc.app.Log().Info(fmt.Sprintf("Processing %d months (of %d remaining)", len(remaining), len(months)-len(uc.state.CompletedMonths)))
+
+	// 4. Process month by month
+	for _, month := range remaining {
+		select {
+		case <-ctx.Done():
+			return context.Cause(ctx)
+		default:
+		}
+		err := uc.processMonth(ctx, adapter, drp, month)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Print batch summary
+	counts := uc.app.FileProcessor().Logger().GetCounts()
+	uploaded := counts[fileevent.ProcessedUploadSuccess]
+	skipped := counts[fileevent.DiscardedServerDuplicate]
+	errCount := counts[fileevent.ErrorUploadFailed] + counts[fileevent.ErrorServerError] + counts[fileevent.ErrorFileAccess]
+
+	firstMonth := remaining[0]
+	lastMonth := remaining[len(remaining)-1]
+	fmt.Printf("\nBatch complete: processed %s through %s (%d months)\n", firstMonth, lastMonth, len(remaining))
+	fmt.Printf("  Uploaded: %d assets\n", uploaded)
+	fmt.Printf("  Skipped:  %d (already on server)\n", skipped)
+	fmt.Printf("  Errors:   %d\n", errCount)
+
+	completedTotal := len(uc.state.CompletedMonths)
+	totalMonths := len(months)
+	nextMonth := ""
+	for _, m := range months {
+		if !uc.state.IsMonthCompleted(m) {
+			nextMonth = m
+			break
+		}
+	}
+	if nextMonth != "" {
+		fmt.Printf("Progress: %d/%d months complete. Next: %s\n", completedTotal, totalMonths, nextMonth)
+	} else {
+		fmt.Printf("Progress: %d/%d months complete. All done!\n", completedTotal, totalMonths)
+	}
+
+	return nil
+}
+
+// processMonth handles uploading all assets for a single month.
+// It creates a fresh asset index, fetches server assets scoped to the month's date range,
+// browses local files for the month, and runs the upload loop.
+func (uc *UpCmd) processMonth(ctx context.Context, adapter adapters.Reader, drp adapters.DateRangeProvider, month string) error {
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(nil)
+
+	uc.app.Log().Info(fmt.Sprintf("Processing month: %s", month))
+	uc.currentMonth = month
+
+	// Fresh asset index per month (key for memory efficiency)
+	uc.assetIndex = newAssetIndex()
+	uc.immichAssetsReady = make(chan struct{})
+
+	// Set in-progress
+	uc.state.SetInProgressMonth(month)
+	if err := uc.state.SaveState(); err != nil {
+		uc.app.Log().Error("can't save state", "err", err)
+	}
+
+	// Create fresh caches per month
+	uc.albumsCache = cache.NewCollectionCache(50, func(album assets.Album, ids []string) (assets.Album, error) {
+		return uc.saveAlbum(ctx, album, ids)
+	})
+	uc.tagsCache = cache.NewCollectionCache(50, func(tag assets.Tag, ids []string) (assets.Tag, error) {
+		return uc.saveTags(ctx, tag, ids)
+	})
+
+	// Reset delete list per month
+	uc.deleteServerList = nil
+	uc.finished = false
+
+	// Determine the browse function for this month
+	groupChan := drp.BrowseMonth(ctx, month)
+
+	// Determine the asset fetch function for this month
+	var dr *cliflags.DateRange
+	if month != "no-date" {
+		after, before, err := adapters.MonthToDateRange(month)
+		if err != nil {
+			return fmt.Errorf("invalid month %q: %w", month, err)
+		}
+		dr = &cliflags.DateRange{After: after, Before: before}
+	}
+
+	// Run the parallel initialization + upload using runMonthNoUI
+	// (always NoUI for batched mode to keep it simple and avoid UI flicker per month)
+	err := uc.runMonthNoUI(ctx, dr, groupChan)
+
+	// Clean up per-month resources
+	if uc.albumsCache != nil {
+		uc.albumsCache.Close()
+		uc.albumsCache = nil
+	}
+	if uc.tagsCache != nil {
+		uc.tagsCache.Close()
+		uc.tagsCache = nil
+	}
+
+	if err != nil {
+		return err
+	}
+
+	// Mark complete
+	uc.state.CompleteMonth(month)
+	if err := uc.state.SaveState(); err != nil {
+		uc.app.Log().Error("can't save state after completing month", "err", err)
+	}
+
+	uc.app.Log().Info(fmt.Sprintf("Completed month: %s", month))
+	return nil
+}
+
+// runMonthNoUI runs the parallel initialization and upload loop for a single month
+// in the batched upload flow. It fetches server assets scoped to the date range,
+// fetches albums, and then runs the upload loop.
+func (uc *UpCmd) runMonthNoUI(ctx context.Context, dr *cliflags.DateRange, groupChan chan *assets.Group) error {
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(nil)
+
+	processGrp := errgroup.Group{}
+
+	processGrp.Go(func() error {
+		var err error
+		if dr != nil {
+			err = uc.getImmichAssetsFiltered(ctx, *dr, nil)
+		} else {
+			// no-date batch: fetch all assets (or skip server fetch)
+			err = uc.getImmichAssetsFiltered(ctx, cliflags.DateRange{}, nil)
+		}
+		if err != nil {
+			cancel(err)
+		}
+		return err
+	})
+	processGrp.Go(func() error {
+		return uc.getImmichAlbums(ctx)
+	})
+
+	err := processGrp.Wait()
+	if err != nil {
+		return context.Cause(ctx)
+	}
+
+	err = uc.uploadLoop(ctx, groupChan)
 	return err
 }
 
@@ -251,6 +516,52 @@ func (uc *UpCmd) getImmichAssets(ctx context.Context, updateFn progressUpdate) e
 		updateFn(totalOnImmich, totalOnImmich)
 	}
 	uc.app.Log().Info(fmt.Sprintf("Assets on the server: %d", uc.assetIndex.len()))
+	return nil
+}
+
+// getImmichAssetsFiltered fetches server assets scoped to a date range
+// (used in batched mode). If the date range is not set, it falls back
+// to GetAllAssets (used for the "no-date" batch).
+func (uc *UpCmd) getImmichAssetsFiltered(ctx context.Context, dr cliflags.DateRange, updateFn progressUpdate) error {
+	defer close(uc.immichAssetsReady)
+	received := 0
+
+	filter := func(a *immich.Asset) error {
+		if updateFn != nil {
+			defer func() {
+				updateFn(received, received)
+			}()
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			received++
+			if a.OwnerID != uc.client.User.ID {
+				return nil
+			}
+			if a.LibraryID != "" {
+				return nil
+			}
+			uc.assetIndex.addImmichAsset(a)
+			return nil
+		}
+	}
+
+	var err error
+	if dr.After.IsZero() && dr.Before.IsZero() {
+		// no-date batch or empty date range: fetch all
+		err = uc.client.Immich.GetAllAssets(ctx, filter)
+	} else {
+		err = uc.client.Immich.GetFilteredAssetsFn(ctx, immich.SearchOptions().All().WithDateRange(dr), filter)
+	}
+	if err != nil {
+		return err
+	}
+	if updateFn != nil {
+		updateFn(received, received)
+	}
+	uc.app.Log().Info(fmt.Sprintf("Assets on the server (filtered): %d", uc.assetIndex.len()))
 	return nil
 }
 
@@ -348,6 +659,19 @@ func (uc *UpCmd) handleAsset(ctx context.Context, a *assets.Asset) error {
 	defer func() {
 		a.Close() // Close and clean resources linked to the local asset
 	}()
+
+	// In batched mode, check if this file was already uploaded in a previous run
+	if uc.state != nil {
+		source := ""
+		if fs, ok := a.File.FS().(interface{ Name() string }); ok {
+			source = fs.Name()
+		}
+		filePath := a.File.Name()
+		if uc.state.IsFileUploaded(source, filePath, int64(a.FileSize)) {
+			uc.app.Log().Debug("Skipping file already uploaded in previous run", "file", filePath)
+			return nil
+		}
+	}
 
 	// var status stri g
 	advice, err := uc.assetIndex.ShouldUpload(a, uc)
@@ -488,6 +812,19 @@ func (uc *UpCmd) uploadAsset(ctx context.Context, a *assets.Asset) (string, erro
 		uc.app.FileProcessor().Logger().Record(ctx, fileevent.ProcessedMetadataUpdated, a.File)
 	}
 	uc.assetIndex.addLocalAsset(a)
+
+	// Record upload in state file for resume support
+	if uc.state != nil {
+		source := ""
+		if fs, ok := a.File.FS().(interface{ Name() string }); ok {
+			source = fs.Name()
+		}
+		uc.state.RecordFileUploaded(source, a.File.Name(), int64(a.FileSize))
+		if err := uc.state.SaveState(); err != nil {
+			uc.app.Log().Error("can't save state after upload", "err", err)
+		}
+	}
+
 	return ar.Status, nil
 }
 

--- a/app/upload/state.go
+++ b/app/upload/state.go
@@ -1,0 +1,185 @@
+package upload
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"time"
+)
+
+// State tracks the progress of a batched upload session.
+// It persists to disk so that interrupted uploads can be resumed.
+type State struct {
+	Version         int            `json:"version"`
+	ArchivePath     string         `json:"archive_path"`
+	ServerURL       string         `json:"server_url"`
+	CreatedAt       time.Time      `json:"created_at"`
+	UpdatedAt       time.Time      `json:"updated_at"`
+	DateRange       StateDateRange `json:"date_range"`
+	CompletedMonths []string       `json:"completed_months"`
+	InProgress      InProgress     `json:"in_progress"`
+
+	// stateDir is the directory where the state file is stored.
+	// Not serialized to JSON.
+	stateDir string
+}
+
+// StateDateRange represents the overall date range of the archive.
+type StateDateRange struct {
+	Min time.Time `json:"min"`
+	Max time.Time `json:"max"`
+}
+
+// InProgress tracks the current month being processed and the files uploaded so far.
+type InProgress struct {
+	Month         string         `json:"month"`
+	UploadedFiles []UploadedFile `json:"uploaded_files"`
+}
+
+// UploadedFile records a file that has been successfully uploaded during the current month.
+type UploadedFile struct {
+	Source string `json:"source"`
+	Path   string `json:"path"`
+	Size   int64  `json:"size"`
+}
+
+const stateVersion = 1
+
+// DefaultStateDir computes the default state directory path for a given server URL and archive path.
+// The directory is ~/.config/immich-go/state/<hash>/ where hash = sha256(archivePath + "|" + serverURL)[:16].
+func DefaultStateDir(serverURL, archivePath string) string {
+	h := sha256.Sum256([]byte(archivePath + "|" + serverURL))
+	hash := fmt.Sprintf("%x", h[:])[:16]
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		configDir = filepath.Join(os.Getenv("HOME"), ".config")
+	}
+	return filepath.Join(configDir, "immich-go", "state", hash)
+}
+
+// LoadState loads the state from stateDir/state.json. If the file does not exist,
+// a new state is created with the given serverURL and archivePath.
+func LoadState(stateDir, serverURL, archivePath string) (*State, error) {
+	stateFile := filepath.Join(stateDir, "state.json")
+
+	data, err := os.ReadFile(stateFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			now := time.Now().UTC().Truncate(time.Second)
+			return &State{
+				Version:         stateVersion,
+				ArchivePath:     archivePath,
+				ServerURL:       serverURL,
+				CreatedAt:       now,
+				UpdatedAt:       now,
+				CompletedMonths: []string{},
+				InProgress: InProgress{
+					UploadedFiles: []UploadedFile{},
+				},
+				stateDir: stateDir,
+			}, nil
+		}
+		return nil, fmt.Errorf("can't read state file %s: %w", stateFile, err)
+	}
+
+	var s State
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, fmt.Errorf("can't parse state file %s: %w", stateFile, err)
+	}
+	s.stateDir = stateDir
+
+	// Ensure slices are non-nil after deserialization.
+	if s.CompletedMonths == nil {
+		s.CompletedMonths = []string{}
+	}
+	if s.InProgress.UploadedFiles == nil {
+		s.InProgress.UploadedFiles = []UploadedFile{}
+	}
+
+	return &s, nil
+}
+
+// SaveState writes the state to disk atomically.
+// It writes to a temporary file in the same directory and renames it into place.
+func (s *State) SaveState() error {
+	s.UpdatedAt = time.Now().UTC().Truncate(time.Second)
+
+	if err := os.MkdirAll(s.stateDir, 0o700); err != nil {
+		return fmt.Errorf("can't create state directory %s: %w", s.stateDir, err)
+	}
+
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return fmt.Errorf("can't marshal state: %w", err)
+	}
+
+	stateFile := filepath.Join(s.stateDir, "state.json")
+	tmpFile := stateFile + ".tmp"
+
+	if err := os.WriteFile(tmpFile, data, 0o600); err != nil {
+		return fmt.Errorf("can't write temporary state file %s: %w", tmpFile, err)
+	}
+
+	if err := os.Rename(tmpFile, stateFile); err != nil {
+		return fmt.Errorf("can't rename temporary state file: %w", err)
+	}
+
+	return nil
+}
+
+// IsMonthCompleted returns true if the given month has already been fully processed.
+func (s *State) IsMonthCompleted(month string) bool {
+	return slices.Contains(s.CompletedMonths, month)
+}
+
+// CompleteMonth marks the in-progress month as completed.
+// It adds the month to CompletedMonths and clears the InProgress uploaded files.
+func (s *State) CompleteMonth(month string) {
+	if !s.IsMonthCompleted(month) {
+		s.CompletedMonths = append(s.CompletedMonths, month)
+	}
+	if s.InProgress.Month == month {
+		s.InProgress.Month = ""
+		s.InProgress.UploadedFiles = []UploadedFile{}
+	}
+}
+
+// IsFileUploaded checks whether a file with the given source, path, and size
+// has already been recorded as uploaded in the current in-progress month.
+func (s *State) IsFileUploaded(source, path string, size int64) bool {
+	for _, f := range s.InProgress.UploadedFiles {
+		if f.Source == source && f.Path == path && f.Size == size {
+			return true
+		}
+	}
+	return false
+}
+
+// RecordFileUploaded adds a file to the in-progress uploaded files list.
+func (s *State) RecordFileUploaded(source, path string, size int64) {
+	s.InProgress.UploadedFiles = append(s.InProgress.UploadedFiles, UploadedFile{
+		Source: source,
+		Path:   path,
+		Size:   size,
+	})
+}
+
+// SetInProgressMonth sets the current in-progress month.
+func (s *State) SetInProgressMonth(month string) {
+	s.InProgress.Month = month
+	s.InProgress.UploadedFiles = []UploadedFile{}
+}
+
+// ResetState clears all progress, resetting the state to its initial condition.
+func (s *State) ResetState() {
+	now := time.Now().UTC().Truncate(time.Second)
+	s.CompletedMonths = []string{}
+	s.InProgress = InProgress{
+		UploadedFiles: []UploadedFile{},
+	}
+	s.DateRange = StateDateRange{}
+	s.UpdatedAt = now
+}

--- a/app/upload/state.go
+++ b/app/upload/state.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"sync"
 	"time"
 )
 
@@ -25,6 +26,7 @@ type State struct {
 	// stateDir is the directory where the state file is stored.
 	// Not serialized to JSON.
 	stateDir string
+	mu       sync.Mutex `json:"-"`
 }
 
 // StateDateRange represents the overall date range of the archive.
@@ -105,6 +107,9 @@ func LoadState(stateDir, serverURL, archivePath string) (*State, error) {
 // SaveState writes the state to disk atomically.
 // It writes to a temporary file in the same directory and renames it into place.
 func (s *State) SaveState() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	s.UpdatedAt = time.Now().UTC().Truncate(time.Second)
 
 	if err := os.MkdirAll(s.stateDir, 0o700); err != nil {
@@ -150,6 +155,9 @@ func (s *State) CompleteMonth(month string) {
 // IsFileUploaded checks whether a file with the given source, path, and size
 // has already been recorded as uploaded in the current in-progress month.
 func (s *State) IsFileUploaded(source, path string, size int64) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	for _, f := range s.InProgress.UploadedFiles {
 		if f.Source == source && f.Path == path && f.Size == size {
 			return true
@@ -160,6 +168,9 @@ func (s *State) IsFileUploaded(source, path string, size int64) bool {
 
 // RecordFileUploaded adds a file to the in-progress uploaded files list.
 func (s *State) RecordFileUploaded(source, path string, size int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	s.InProgress.UploadedFiles = append(s.InProgress.UploadedFiles, UploadedFile{
 		Source: source,
 		Path:   path,

--- a/app/upload/state.go
+++ b/app/upload/state.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
 	"sync"
 	"time"
 )
@@ -25,8 +24,13 @@ type State struct {
 
 	// stateDir is the directory where the state file is stored.
 	// Not serialized to JSON.
-	stateDir string
-	mu       sync.Mutex `json:"-"`
+	stateDir       string
+	mu             sync.Mutex      `json:"-"`
+	completedSet   map[string]bool // O(1) lookup for completed months
+	uploadedSet    map[string]bool // O(1) lookup for uploaded files
+	savePending    bool            // true when records changed since last save
+	saveInterval   int             // save every N records (0 = every record)
+	recordsSince   int             // records since last save
 }
 
 // StateDateRange represents the overall date range of the archive.
@@ -50,6 +54,11 @@ type UploadedFile struct {
 
 const stateVersion = 1
 
+// uploadedFileKey returns a map key for an uploaded file.
+func uploadedFileKey(source, path string, size int64) string {
+	return fmt.Sprintf("%s|%s|%d", source, path, size)
+}
+
 // DefaultStateDir computes the default state directory path for a given server URL and archive path.
 // The directory is ~/.config/immich-go/state/<hash>/ where hash = sha256(archivePath + "|" + serverURL)[:16].
 func DefaultStateDir(serverURL, archivePath string) string {
@@ -62,6 +71,19 @@ func DefaultStateDir(serverURL, archivePath string) string {
 	return filepath.Join(configDir, "immich-go", "state", hash)
 }
 
+// buildLookupSets populates the O(1) lookup maps from the serialized slices.
+func (s *State) buildLookupSets() {
+	s.completedSet = make(map[string]bool, len(s.CompletedMonths))
+	for _, m := range s.CompletedMonths {
+		s.completedSet[m] = true
+	}
+	s.uploadedSet = make(map[string]bool, len(s.InProgress.UploadedFiles))
+	for _, f := range s.InProgress.UploadedFiles {
+		s.uploadedSet[uploadedFileKey(f.Source, f.Path, f.Size)] = true
+	}
+	s.saveInterval = 50 // save every 50 records instead of every record
+}
+
 // LoadState loads the state from stateDir/state.json. If the file does not exist,
 // a new state is created with the given serverURL and archivePath.
 func LoadState(stateDir, serverURL, archivePath string) (*State, error) {
@@ -71,7 +93,7 @@ func LoadState(stateDir, serverURL, archivePath string) (*State, error) {
 	if err != nil {
 		if os.IsNotExist(err) {
 			now := time.Now().UTC().Truncate(time.Second)
-			return &State{
+			s := &State{
 				Version:         stateVersion,
 				ArchivePath:     archivePath,
 				ServerURL:       serverURL,
@@ -82,7 +104,9 @@ func LoadState(stateDir, serverURL, archivePath string) (*State, error) {
 					UploadedFiles: []UploadedFile{},
 				},
 				stateDir: stateDir,
-			}, nil
+			}
+			s.buildLookupSets()
+			return s, nil
 		}
 		return nil, fmt.Errorf("can't read state file %s: %w", stateFile, err)
 	}
@@ -101,6 +125,7 @@ func LoadState(stateDir, serverURL, archivePath string) (*State, error) {
 		s.InProgress.UploadedFiles = []UploadedFile{}
 	}
 
+	s.buildLookupSets()
 	return &s, nil
 }
 
@@ -110,6 +135,8 @@ func (s *State) SaveState() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	s.savePending = false
+	s.recordsSince = 0
 	s.UpdatedAt = time.Now().UTC().Truncate(time.Second)
 
 	if err := os.MkdirAll(s.stateDir, 0o700); err != nil {
@@ -137,7 +164,7 @@ func (s *State) SaveState() error {
 
 // IsMonthCompleted returns true if the given month has already been fully processed.
 func (s *State) IsMonthCompleted(month string) bool {
-	return slices.Contains(s.CompletedMonths, month)
+	return s.completedSet[month]
 }
 
 // CompleteMonth marks the in-progress month as completed.
@@ -145,10 +172,12 @@ func (s *State) IsMonthCompleted(month string) bool {
 func (s *State) CompleteMonth(month string) {
 	if !s.IsMonthCompleted(month) {
 		s.CompletedMonths = append(s.CompletedMonths, month)
+		s.completedSet[month] = true
 	}
 	if s.InProgress.Month == month {
 		s.InProgress.Month = ""
 		s.InProgress.UploadedFiles = []UploadedFile{}
+		s.uploadedSet = make(map[string]bool)
 	}
 }
 
@@ -158,30 +187,32 @@ func (s *State) IsFileUploaded(source, path string, size int64) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	for _, f := range s.InProgress.UploadedFiles {
-		if f.Source == source && f.Path == path && f.Size == size {
-			return true
-		}
-	}
-	return false
+	return s.uploadedSet[uploadedFileKey(source, path, size)]
 }
 
 // RecordFileUploaded adds a file to the in-progress uploaded files list.
-func (s *State) RecordFileUploaded(source, path string, size int64) {
+// Returns true if a periodic save should be performed by the caller.
+func (s *State) RecordFileUploaded(source, path string, size int64) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	key := uploadedFileKey(source, path, size)
+	s.uploadedSet[key] = true
 	s.InProgress.UploadedFiles = append(s.InProgress.UploadedFiles, UploadedFile{
 		Source: source,
 		Path:   path,
 		Size:   size,
 	})
+	s.savePending = true
+	s.recordsSince++
+	return s.saveInterval > 0 && s.recordsSince >= s.saveInterval
 }
 
 // SetInProgressMonth sets the current in-progress month.
 func (s *State) SetInProgressMonth(month string) {
 	s.InProgress.Month = month
 	s.InProgress.UploadedFiles = []UploadedFile{}
+	s.uploadedSet = make(map[string]bool)
 }
 
 // ResetState clears all progress, resetting the state to its initial condition.
@@ -193,4 +224,16 @@ func (s *State) ResetState() {
 	}
 	s.DateRange = StateDateRange{}
 	s.UpdatedAt = now
+	s.buildLookupSets()
+}
+
+// FlushState saves state to disk if there are pending changes.
+func (s *State) FlushState() error {
+	s.mu.Lock()
+	pending := s.savePending
+	s.mu.Unlock()
+	if !pending {
+		return nil
+	}
+	return s.SaveState()
 }

--- a/app/upload/state_test.go
+++ b/app/upload/state_test.go
@@ -54,14 +54,13 @@ func TestStateSaveLoadRoundTrip(t *testing.T) {
 		Min: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
 		Max: time.Date(2024, 12, 31, 0, 0, 0, 0, time.UTC),
 	}
-	original.CompletedMonths = []string{"2020-01", "2020-02", "2020-03"}
-	original.InProgress = InProgress{
-		Month: "2020-04",
-		UploadedFiles: []UploadedFile{
-			{Source: "archive.zip", Path: "Photos/IMG_001.HEIC", Size: 1234567},
-			{Source: "archive.zip", Path: "Photos/IMG_002.JPG", Size: 7654321},
-		},
-	}
+	// Use the proper API to populate state so lookup sets stay in sync
+	original.CompleteMonth("2020-01")
+	original.CompleteMonth("2020-02")
+	original.CompleteMonth("2020-03")
+	original.SetInProgressMonth("2020-04")
+	original.RecordFileUploaded("archive.zip", "Photos/IMG_001.HEIC", 1234567)
+	original.RecordFileUploaded("archive.zip", "Photos/IMG_002.JPG", 7654321)
 
 	if err := original.SaveState(); err != nil {
 		t.Fatalf("SaveState failed: %v", err)
@@ -232,12 +231,13 @@ func TestStateResetState(t *testing.T) {
 		t.Fatalf("LoadState failed: %v", err)
 	}
 
-	// Populate state
+	// Populate state using proper API
 	s.DateRange = StateDateRange{
 		Min: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
 		Max: time.Date(2024, 12, 31, 0, 0, 0, 0, time.UTC),
 	}
-	s.CompletedMonths = []string{"2020-01", "2020-02"}
+	s.CompleteMonth("2020-01")
+	s.CompleteMonth("2020-02")
 	s.SetInProgressMonth("2020-03")
 	s.RecordFileUploaded("archive.zip", "Photos/IMG_001.HEIC", 1000)
 

--- a/app/upload/state_test.go
+++ b/app/upload/state_test.go
@@ -1,0 +1,312 @@
+package upload
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestStateCreation(t *testing.T) {
+	dir := t.TempDir()
+
+	s, err := LoadState(dir, "https://immich.example.com", "/path/to/archive")
+	if err != nil {
+		t.Fatalf("LoadState failed: %v", err)
+	}
+
+	if s.Version != stateVersion {
+		t.Errorf("expected version %d, got %d", stateVersion, s.Version)
+	}
+	if s.ArchivePath != "/path/to/archive" {
+		t.Errorf("expected archive_path %q, got %q", "/path/to/archive", s.ArchivePath)
+	}
+	if s.ServerURL != "https://immich.example.com" {
+		t.Errorf("expected server_url %q, got %q", "https://immich.example.com", s.ServerURL)
+	}
+	if s.CreatedAt.IsZero() {
+		t.Error("expected created_at to be set")
+	}
+	if s.UpdatedAt.IsZero() {
+		t.Error("expected updated_at to be set")
+	}
+	if len(s.CompletedMonths) != 0 {
+		t.Errorf("expected empty completed_months, got %v", s.CompletedMonths)
+	}
+	if s.InProgress.Month != "" {
+		t.Errorf("expected empty in_progress month, got %q", s.InProgress.Month)
+	}
+	if len(s.InProgress.UploadedFiles) != 0 {
+		t.Errorf("expected empty uploaded_files, got %v", s.InProgress.UploadedFiles)
+	}
+}
+
+func TestStateSaveLoadRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+
+	original, err := LoadState(dir, "https://immich.example.com", "/path/to/archive")
+	if err != nil {
+		t.Fatalf("LoadState failed: %v", err)
+	}
+
+	// Populate all fields
+	original.DateRange = StateDateRange{
+		Min: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+		Max: time.Date(2024, 12, 31, 0, 0, 0, 0, time.UTC),
+	}
+	original.CompletedMonths = []string{"2020-01", "2020-02", "2020-03"}
+	original.InProgress = InProgress{
+		Month: "2020-04",
+		UploadedFiles: []UploadedFile{
+			{Source: "archive.zip", Path: "Photos/IMG_001.HEIC", Size: 1234567},
+			{Source: "archive.zip", Path: "Photos/IMG_002.JPG", Size: 7654321},
+		},
+	}
+
+	if err := original.SaveState(); err != nil {
+		t.Fatalf("SaveState failed: %v", err)
+	}
+
+	// Verify the file was written
+	stateFile := filepath.Join(dir, "state.json")
+	if _, err := os.Stat(stateFile); os.IsNotExist(err) {
+		t.Fatal("state.json file was not created")
+	}
+
+	// Load back
+	loaded, err := LoadState(dir, "https://immich.example.com", "/path/to/archive")
+	if err != nil {
+		t.Fatalf("LoadState after save failed: %v", err)
+	}
+
+	// Verify all fields survived serialization
+	if loaded.Version != original.Version {
+		t.Errorf("version: expected %d, got %d", original.Version, loaded.Version)
+	}
+	if loaded.ArchivePath != original.ArchivePath {
+		t.Errorf("archive_path: expected %q, got %q", original.ArchivePath, loaded.ArchivePath)
+	}
+	if loaded.ServerURL != original.ServerURL {
+		t.Errorf("server_url: expected %q, got %q", original.ServerURL, loaded.ServerURL)
+	}
+	if !loaded.CreatedAt.Equal(original.CreatedAt) {
+		t.Errorf("created_at: expected %v, got %v", original.CreatedAt, loaded.CreatedAt)
+	}
+	if !loaded.DateRange.Min.Equal(original.DateRange.Min) {
+		t.Errorf("date_range.min: expected %v, got %v", original.DateRange.Min, loaded.DateRange.Min)
+	}
+	if !loaded.DateRange.Max.Equal(original.DateRange.Max) {
+		t.Errorf("date_range.max: expected %v, got %v", original.DateRange.Max, loaded.DateRange.Max)
+	}
+	if len(loaded.CompletedMonths) != len(original.CompletedMonths) {
+		t.Fatalf("completed_months length: expected %d, got %d", len(original.CompletedMonths), len(loaded.CompletedMonths))
+	}
+	for i, m := range original.CompletedMonths {
+		if loaded.CompletedMonths[i] != m {
+			t.Errorf("completed_months[%d]: expected %q, got %q", i, m, loaded.CompletedMonths[i])
+		}
+	}
+	if loaded.InProgress.Month != original.InProgress.Month {
+		t.Errorf("in_progress.month: expected %q, got %q", original.InProgress.Month, loaded.InProgress.Month)
+	}
+	if len(loaded.InProgress.UploadedFiles) != len(original.InProgress.UploadedFiles) {
+		t.Fatalf("uploaded_files length: expected %d, got %d", len(original.InProgress.UploadedFiles), len(loaded.InProgress.UploadedFiles))
+	}
+	for i, f := range original.InProgress.UploadedFiles {
+		lf := loaded.InProgress.UploadedFiles[i]
+		if lf.Source != f.Source || lf.Path != f.Path || lf.Size != f.Size {
+			t.Errorf("uploaded_files[%d]: expected %+v, got %+v", i, f, lf)
+		}
+	}
+}
+
+func TestStateMonthCompletionFlow(t *testing.T) {
+	dir := t.TempDir()
+
+	s, err := LoadState(dir, "https://immich.example.com", "/archive")
+	if err != nil {
+		t.Fatalf("LoadState failed: %v", err)
+	}
+
+	month := "2023-06"
+
+	// Month should not be completed initially
+	if s.IsMonthCompleted(month) {
+		t.Error("month should not be completed initially")
+	}
+
+	// Set in-progress
+	s.SetInProgressMonth(month)
+	if s.InProgress.Month != month {
+		t.Errorf("expected in_progress month %q, got %q", month, s.InProgress.Month)
+	}
+
+	// Record some files
+	s.RecordFileUploaded("archive.zip", "Photos/IMG_001.HEIC", 1000)
+	s.RecordFileUploaded("archive.zip", "Photos/IMG_002.JPG", 2000)
+
+	if len(s.InProgress.UploadedFiles) != 2 {
+		t.Fatalf("expected 2 uploaded files, got %d", len(s.InProgress.UploadedFiles))
+	}
+
+	// Complete the month
+	s.CompleteMonth(month)
+
+	if !s.IsMonthCompleted(month) {
+		t.Error("month should be completed after CompleteMonth")
+	}
+	if s.InProgress.Month != "" {
+		t.Errorf("expected empty in_progress month after completion, got %q", s.InProgress.Month)
+	}
+	if len(s.InProgress.UploadedFiles) != 0 {
+		t.Errorf("expected empty uploaded_files after completion, got %d", len(s.InProgress.UploadedFiles))
+	}
+
+	// Completing the same month again should not duplicate it
+	s.CompleteMonth(month)
+	count := 0
+	for _, m := range s.CompletedMonths {
+		if m == month {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("month should appear exactly once in completed_months, got %d", count)
+	}
+}
+
+func TestStateIsFileUploaded(t *testing.T) {
+	dir := t.TempDir()
+
+	s, err := LoadState(dir, "https://immich.example.com", "/archive")
+	if err != nil {
+		t.Fatalf("LoadState failed: %v", err)
+	}
+
+	s.SetInProgressMonth("2023-06")
+	s.RecordFileUploaded("archive.zip", "Photos/IMG_001.HEIC", 1000)
+
+	// Exact match
+	if !s.IsFileUploaded("archive.zip", "Photos/IMG_001.HEIC", 1000) {
+		t.Error("expected file to be found as uploaded")
+	}
+
+	// Different source
+	if s.IsFileUploaded("other.zip", "Photos/IMG_001.HEIC", 1000) {
+		t.Error("expected file with different source to not match")
+	}
+
+	// Different path
+	if s.IsFileUploaded("archive.zip", "Photos/IMG_999.HEIC", 1000) {
+		t.Error("expected file with different path to not match")
+	}
+
+	// Different size
+	if s.IsFileUploaded("archive.zip", "Photos/IMG_001.HEIC", 9999) {
+		t.Error("expected file with different size to not match")
+	}
+}
+
+func TestStateHashUniqueness(t *testing.T) {
+	dir1 := DefaultStateDir("https://server1.com", "/archive/a")
+	dir2 := DefaultStateDir("https://server2.com", "/archive/a")
+	dir3 := DefaultStateDir("https://server1.com", "/archive/b")
+	dir4 := DefaultStateDir("https://server1.com", "/archive/a") // same as dir1
+
+	if dir1 == dir2 {
+		t.Error("different server URLs should produce different state dirs")
+	}
+	if dir1 == dir3 {
+		t.Error("different archive paths should produce different state dirs")
+	}
+	if dir1 != dir4 {
+		t.Error("same inputs should produce the same state dir")
+	}
+}
+
+func TestStateResetState(t *testing.T) {
+	dir := t.TempDir()
+
+	s, err := LoadState(dir, "https://immich.example.com", "/archive")
+	if err != nil {
+		t.Fatalf("LoadState failed: %v", err)
+	}
+
+	// Populate state
+	s.DateRange = StateDateRange{
+		Min: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+		Max: time.Date(2024, 12, 31, 0, 0, 0, 0, time.UTC),
+	}
+	s.CompletedMonths = []string{"2020-01", "2020-02"}
+	s.SetInProgressMonth("2020-03")
+	s.RecordFileUploaded("archive.zip", "Photos/IMG_001.HEIC", 1000)
+
+	// Reset
+	s.ResetState()
+
+	if len(s.CompletedMonths) != 0 {
+		t.Errorf("expected empty completed_months after reset, got %v", s.CompletedMonths)
+	}
+	if s.InProgress.Month != "" {
+		t.Errorf("expected empty in_progress month after reset, got %q", s.InProgress.Month)
+	}
+	if len(s.InProgress.UploadedFiles) != 0 {
+		t.Errorf("expected empty uploaded_files after reset, got %d", len(s.InProgress.UploadedFiles))
+	}
+	if !s.DateRange.Min.IsZero() {
+		t.Error("expected zero date_range.min after reset")
+	}
+	if !s.DateRange.Max.IsZero() {
+		t.Error("expected zero date_range.max after reset")
+	}
+
+	// Version and identity fields should be preserved
+	if s.Version != stateVersion {
+		t.Errorf("expected version %d after reset, got %d", stateVersion, s.Version)
+	}
+	if s.ArchivePath != "/archive" {
+		t.Errorf("expected archive_path preserved after reset, got %q", s.ArchivePath)
+	}
+	if s.ServerURL != "https://immich.example.com" {
+		t.Errorf("expected server_url preserved after reset, got %q", s.ServerURL)
+	}
+}
+
+func TestStateSaveCreatesDirectory(t *testing.T) {
+	dir := t.TempDir()
+	nestedDir := filepath.Join(dir, "nested", "deep", "state")
+
+	s, err := LoadState(nestedDir, "https://immich.example.com", "/archive")
+	if err != nil {
+		t.Fatalf("LoadState failed: %v", err)
+	}
+
+	if err := s.SaveState(); err != nil {
+		t.Fatalf("SaveState failed: %v", err)
+	}
+
+	stateFile := filepath.Join(nestedDir, "state.json")
+	if _, err := os.Stat(stateFile); os.IsNotExist(err) {
+		t.Fatal("state.json file was not created in nested directory")
+	}
+}
+
+func TestStateAtomicWrite(t *testing.T) {
+	dir := t.TempDir()
+
+	s, err := LoadState(dir, "https://immich.example.com", "/archive")
+	if err != nil {
+		t.Fatalf("LoadState failed: %v", err)
+	}
+
+	// Save initial state
+	if err := s.SaveState(); err != nil {
+		t.Fatalf("SaveState failed: %v", err)
+	}
+
+	// Verify no temp file is left behind
+	tmpFile := filepath.Join(dir, "state.json.tmp")
+	if _, err := os.Stat(tmpFile); !os.IsNotExist(err) {
+		t.Error("temporary file should not exist after successful save")
+	}
+}

--- a/app/upload/ui.go
+++ b/app/upload/ui.go
@@ -736,29 +736,13 @@ func (ui *uiPage) updateStatusZone() {
 			ui.uploadStartTime = time.Now()
 		} else if elapsed := time.Since(ui.uploadStartTime).Seconds(); elapsed > 0 {
 			bytesPerSec := float64(processedSize) / elapsed
-			speed := ui.formatSpeed(bytesPerSec)
+			speed := formatSpeed(bytesPerSec)
 			ui.statusZone.SetTitle(fmt.Sprintf("Progress - %s", speed))
 			ui.statusViews["uploadedSize"].SetText(fmt.Sprintf("%s (%s)", ui.formatBytes(processedSize), speed))
 		}
 	}
 }
 
-// formatSpeed formats bytes/sec as human-readable speed string
-func (ui *uiPage) formatSpeed(bytesPerSec float64) string {
-	if bytesPerSec < 1 {
-		return "— "
-	}
-	const unit = 1024
-	if bytesPerSec < unit {
-		return fmt.Sprintf("%.0f B/s", bytesPerSec)
-	}
-	div, exp := float64(unit), 0
-	for n := bytesPerSec / unit; n >= unit; n /= unit {
-		div *= unit
-		exp++
-	}
-	return fmt.Sprintf("%.1f %cB/s", bytesPerSec/div, "KMGTPE"[exp])
-}
 
 // formatBytes formats byte count as human-readable string
 func (ui *uiPage) formatBytes(bytes int64) string {

--- a/app/upload/ui.go
+++ b/app/upload/ui.go
@@ -58,6 +58,9 @@ type uiPage struct {
 	// Batch progress (for batched upload mode)
 	batchInfoView     *tview.TextView
 	resumeSkippedView *tview.TextView
+
+	// Speed tracking
+	uploadStartTime time.Time // set when first bytes are processed
 }
 
 func (ui *uiPage) highJackLogger(app *app.Application) {
@@ -372,6 +375,9 @@ func (uc *UpCmd) runBatchedUI(ctx context.Context, monthLoop func(ctx context.Co
 		}
 	})
 
+	// Wire the Immich content progress bar to the batched asset fetching
+	uc.immichUpdateFn = ui.updateImmichReading
+
 	// run the month loop
 	uiGroup.Go(func() error {
 		err := monthLoop(ctx)
@@ -684,9 +690,13 @@ func (ui *uiPage) addDiscoveryCounter(g *tview.Grid, row int, countKey, sizeKey 
 
 // updateStatusZone updates the status zone with current asset tracker data
 func (ui *uiPage) updateStatusZone() {
+	if ui.fileProcessor != nil {
+		ui.tracker = ui.fileProcessor.Tracker()
+	}
 	if ui.tracker == nil {
 		return
 	}
+
 
 	// Get current counters
 	pendingCount := ui.tracker.GetPendingCount()
@@ -719,6 +729,35 @@ func (ui *uiPage) updateStatusZone() {
 		ui.discoveryViews["discoveredCount"].SetText(fmt.Sprintf("%6d", totalCount))
 		ui.discoveryViews["discoveredSize"].SetText(ui.formatBytes(totalSize))
 	}
+
+	// Update upload speed (average since first upload completed)
+	if processedSize > 0 {
+		if ui.uploadStartTime.IsZero() {
+			ui.uploadStartTime = time.Now()
+		} else if elapsed := time.Since(ui.uploadStartTime).Seconds(); elapsed > 0 {
+			bytesPerSec := float64(processedSize) / elapsed
+			speed := ui.formatSpeed(bytesPerSec)
+			ui.statusZone.SetTitle(fmt.Sprintf("Progress - %s", speed))
+			ui.statusViews["uploadedSize"].SetText(fmt.Sprintf("%s (%s)", ui.formatBytes(processedSize), speed))
+		}
+	}
+}
+
+// formatSpeed formats bytes/sec as human-readable speed string
+func (ui *uiPage) formatSpeed(bytesPerSec float64) string {
+	if bytesPerSec < 1 {
+		return "— "
+	}
+	const unit = 1024
+	if bytesPerSec < unit {
+		return fmt.Sprintf("%.0f B/s", bytesPerSec)
+	}
+	div, exp := float64(unit), 0
+	for n := bytesPerSec / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB/s", bytesPerSec/div, "KMGTPE"[exp])
 }
 
 // formatBytes formats byte count as human-readable string

--- a/app/upload/ui.go
+++ b/app/upload/ui.go
@@ -54,6 +54,9 @@ type uiPage struct {
 	immichUpload  *tvxwidgets.PercentageModeGauge
 
 	watchJobs bool
+
+	// Batch progress (for batched upload mode)
+	batchInfo *tview.TextView
 }
 
 func (ui *uiPage) highJackLogger(app *app.Application) {
@@ -254,6 +257,147 @@ func (uc *UpCmd) runUI(ctx context.Context, app *app.Application) error {
 	return err
 }
 
+// runBatchedUI runs the TUI for batched upload mode.
+// It starts the TUI once and runs the month loop inside it, so the user
+// sees live counters and progress across all months.
+func (uc *UpCmd) runBatchedUI(ctx context.Context, monthLoop func(ctx context.Context) error) error {
+	ctx, cancel := context.WithCancelCause(ctx)
+	uiApp := tview.NewApplication()
+	ui := uc.newUI(ctx, uc.app)
+
+	defer cancel(nil)
+	pages := tview.NewPages()
+
+	var uploadDone atomic.Bool
+	var uiGroup errgroup.Group
+	var messages strings.Builder
+
+	uiApp.SetRoot(pages, true)
+
+	stopUI := func(err error) {
+		cancel(err)
+		if uiApp != nil {
+			uiApp.Stop()
+		}
+	}
+
+	pages.AddPage("ui", ui.screen, true, true)
+
+	// handle Ctrl+C and Ctrl+Q
+	uiApp.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+		switch event.Key() {
+		case tcell.KeyCtrlQ, tcell.KeyCtrlC:
+			ui.restoreLogger(uc.app)
+			cancel(errors.New("interrupted: Ctrl+C or Ctrl+Q pressed"))
+		case tcell.KeyEnter:
+			if uploadDone.Load() {
+				stopUI(nil)
+			}
+		}
+		return event
+	})
+
+	// update server status
+	if ui.watchJobs {
+		go func() {
+			tick := time.NewTicker(250 * time.Millisecond)
+			for {
+				select {
+				case <-ctx.Done():
+					tick.Stop()
+					return
+				case <-tick.C:
+					jobs, err := uc.client.AdminImmich.GetJobs(ctx)
+					if err == nil {
+						jobCount := 0
+						jobWaiting := 0
+						for _, j := range jobs {
+							jobCount += j.JobCounts.Active
+							jobWaiting += j.JobCounts.Waiting
+						}
+						_, _, w, _ := ui.serverJobs.GetInnerRect()
+						ui.serverActivity = append(ui.serverActivity, float64(jobCount))
+						if len(ui.serverActivity) > w {
+							ui.serverActivity = ui.serverActivity[1:]
+						}
+						ui.serverJobs.SetData(ui.serverActivity)
+						ui.serverJobs.SetTitle(fmt.Sprintf("Server's jobs: active: %d, waiting: %d", jobCount, jobWaiting))
+						if jobCount > 0 {
+							ui.lastTimeServerActive.Store(time.Now().Unix())
+						}
+					}
+				}
+			}
+		}()
+	}
+
+	// force the ui to redraw counters
+	go func() {
+		tick := time.NewTicker(100 * time.Millisecond)
+		for {
+			select {
+			case <-ctx.Done():
+				tick.Stop()
+				return
+			case <-tick.C:
+				uiApp.QueueUpdateDraw(func() {
+					counts := uc.app.FileProcessor().Logger().GetCounts()
+					sizes := uc.app.FileProcessor().Logger().GetEventSizes()
+					for c := range ui.counts {
+						ui.getCountView(c, counts[c])
+						ui.updateSizeView(c, sizes[c])
+					}
+					ui.updateStatusZone()
+					if ui.batchInfo != nil && uc.batchTotal > 0 {
+						ui.batchInfo.SetText(fmt.Sprintf("[yellow]Batch %d/%d[white]  Month: [green]%s", uc.batchCurrent, uc.batchTotal, uc.currentMonth))
+					}
+				})
+			}
+		}
+	}()
+
+	// start the UI
+	uiGroup.Go(func() error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			err := uiApp.Run()
+			cancel(err)
+			return err
+		}
+	})
+
+	// run the month loop
+	uiGroup.Go(func() error {
+		err := monthLoop(ctx)
+
+		err = errors.Join(err, uc.finishing(ctx))
+
+		uploadDone.Store(true)
+		counts := uc.app.FileProcessor().Logger().GetCounts()
+		if counts[fileevent.ErrorUploadFailed]+counts[fileevent.ErrorServerError]+counts[fileevent.ErrorFileAccess]+counts[fileevent.ErrorIncomplete] > 0 {
+			messages.WriteString("Some errors have occurred. Look at the log file for details\n")
+		}
+
+		modal := newModal(messages.String())
+		pages.AddPage("modal", modal, true, false)
+		pages.ShowPage("modal")
+
+		return err
+	})
+
+	err := uiGroup.Wait()
+	if err != nil {
+		err = context.Cause(ctx)
+	}
+
+	if messages.Len() > 0 {
+		return errors.New(messages.String())
+	}
+	return err
+}
+
 func newModal(message string) tview.Primitive {
 	message += "\nYou can quit the program safely.\n\nPress the [enter] key to exit."
 	lines := strings.Count(message, "\n")
@@ -353,6 +497,10 @@ func (uc *UpCmd) newUI(ctx context.Context, a *app.Application) *uiPage {
 		ui.footer.AddItem(tview.NewTextView().SetText("Google Photo puzzle:").SetTextAlign(tview.AlignCenter), 0, 2, 1, 1, 0, 0, false).AddItem(ui.immichPrepare, 0, 3, 1, 1, 0, 0, false)
 		ui.footer.AddItem(tview.NewTextView().SetText("Uploading:").SetTextAlign(tview.AlignCenter), 0, 4, 1, 1, 0, 0, false).AddItem(ui.immichUpload, 0, 5, 1, 1, 0, 0, false)
 		ui.footer.SetColumns(25, 0, 25, 0, 25, 0)
+	} else if uc.batchTotal > 0 {
+		ui.batchInfo = tview.NewTextView().SetTextAlign(tview.AlignCenter).SetDynamicColors(true)
+		ui.footer.AddItem(ui.batchInfo, 0, 2, 1, 1, 0, 0, false)
+		ui.footer.SetColumns(25, 0, 0)
 	} else {
 		ui.footer.SetColumns(25, 0)
 	}

--- a/app/upload/ui.go
+++ b/app/upload/ui.go
@@ -56,7 +56,8 @@ type uiPage struct {
 	watchJobs bool
 
 	// Batch progress (for batched upload mode)
-	batchInfo *tview.TextView
+	batchInfoView     *tview.TextView
+	resumeSkippedView *tview.TextView
 }
 
 func (ui *uiPage) highJackLogger(app *app.Application) {
@@ -348,8 +349,11 @@ func (uc *UpCmd) runBatchedUI(ctx context.Context, monthLoop func(ctx context.Co
 						ui.updateSizeView(c, sizes[c])
 					}
 					ui.updateStatusZone()
-					if ui.batchInfo != nil && uc.batchTotal > 0 {
-						ui.batchInfo.SetText(fmt.Sprintf("[yellow]Batch %d/%d[white]  Month: [green]%s", uc.batchCurrent, uc.batchTotal, uc.currentMonth))
+					if ui.batchInfoView != nil && uc.batchTotal > 0 {
+						ui.batchInfoView.SetText(fmt.Sprintf("Batch %d/%d: %s", uc.batchCurrent, uc.batchTotal, uc.currentMonth))
+					}
+					if ui.resumeSkippedView != nil {
+						ui.resumeSkippedView.SetText(fmt.Sprintf("%d", uc.resumeSkipped.Load()))
 					}
 				})
 			}
@@ -497,10 +501,6 @@ func (uc *UpCmd) newUI(ctx context.Context, a *app.Application) *uiPage {
 		ui.footer.AddItem(tview.NewTextView().SetText("Google Photo puzzle:").SetTextAlign(tview.AlignCenter), 0, 2, 1, 1, 0, 0, false).AddItem(ui.immichPrepare, 0, 3, 1, 1, 0, 0, false)
 		ui.footer.AddItem(tview.NewTextView().SetText("Uploading:").SetTextAlign(tview.AlignCenter), 0, 4, 1, 1, 0, 0, false).AddItem(ui.immichUpload, 0, 5, 1, 1, 0, 0, false)
 		ui.footer.SetColumns(25, 0, 25, 0, 25, 0)
-	} else if uc.batchTotal > 0 {
-		ui.batchInfo = tview.NewTextView().SetTextAlign(tview.AlignCenter).SetDynamicColors(true)
-		ui.footer.AddItem(ui.batchInfo, 0, 2, 1, 1, 0, 0, false)
-		ui.footer.SetColumns(25, 0, 0)
 	} else {
 		ui.footer.SetColumns(25, 0)
 	}
@@ -584,11 +584,15 @@ func (ui *uiPage) createDiscoveryZone() *tview.Grid {
 	ui.addCounter(discovery, 6, "Banned", fileevent.DiscardedBanned)
 	// Row 7: Missing sidecar
 	ui.addCounter(discovery, 7, "Missing sidecar", fileevent.ProcessedMissingMetadata)
-	// Row 8: Total discovered
-	discovery.AddItem(tview.NewTextView().SetText("Total discovered"), 8, 0, 1, 1, 0, 0, false)
-	ui.addDiscoveryCounter(discovery, 8, "discoveredCount", "discoveredSize")
+	// Row 8: Skipped (resume) — custom counter, not a fileevent
+	discovery.AddItem(tview.NewTextView().SetText("Skipped (resume)"), 8, 0, 1, 1, 0, 0, false)
+	ui.resumeSkippedView = tview.NewTextView().SetTextAlign(tview.AlignRight).SetText("0")
+	discovery.AddItem(ui.resumeSkippedView, 8, 1, 1, 1, 0, 0, false)
+	// Row 9: Total discovered
+	discovery.AddItem(tview.NewTextView().SetText("Total discovered"), 9, 0, 1, 1, 0, 0, false)
+	ui.addDiscoveryCounter(discovery, 9, "discoveredCount", "discoveredSize")
 
-	discovery.SetSize(9, 4, 1, 1).SetColumns(20, 8, 2, 10)
+	discovery.SetSize(10, 4, 1, 1).SetColumns(20, 8, 2, 10)
 	return discovery
 }
 
@@ -607,8 +611,11 @@ func (ui *uiPage) createProcessingZone() *tview.Grid {
 	ui.addProcessingCounter(processing, 3, "Tagged", fileevent.ProcessedTagged)
 	// Row 4: Metadata updated
 	ui.addProcessingCounter(processing, 4, "Metadata updated", fileevent.ProcessedMetadataUpdated)
+	// Row 5: Batch info (empty until batched mode sets it)
+	ui.batchInfoView = tview.NewTextView().SetDynamicColors(true)
+	processing.AddItem(ui.batchInfoView, 5, 0, 1, 2, 0, 0, false)
 
-	processing.SetSize(5, 2, 1, 1).SetColumns(20, 10)
+	processing.SetSize(6, 2, 1, 1).SetColumns(20, 10)
 	return processing
 }
 

--- a/app/upload/upload.go
+++ b/app/upload/upload.go
@@ -62,6 +62,12 @@ type UpCmd struct {
 	SessionTag bool
 	session    string // Session tag value
 
+	// Batched upload flags
+	BatchLimit int    // max months to process (0 = unlimited)
+	StateDir   string // override state directory
+	ResetState bool   // clear saved state
+	ShowState  bool   // print state and exit
+
 	// Upload command state
 	// Filters           []filters.Filter
 	tz                *time.Location
@@ -77,6 +83,8 @@ type UpCmd struct {
 	tagsCache         *cache.CollectionCache[assets.Tag]   // List of tags present on the server
 	finished          bool                                 // the finish task has been run
 	infoCollector     *filenames.InfoCollector             // Collects information about the files being processed
+	state             *State                               // runtime state tracking for batched uploads
+	currentMonth      string                               // current month being processed in batched mode
 }
 
 func (uc *UpCmd) RegisterFlags(flags *pflag.FlagSet) {
@@ -85,6 +93,12 @@ func (uc *UpCmd) RegisterFlags(flags *pflag.FlagSet) {
 	flags.BoolVar(&uc.Overwrite, "overwrite", false, "Always overwrite files on the server with local versions")
 	flags.StringSliceVar(&uc.Tags, "tag", nil, "Add tags to the imported assets. Can be specified multiple times. Hierarchy is supported using a / separator (e.g. 'tag1/subtag1')")
 	flags.BoolVar(&uc.SessionTag, "session-tag", false, "Tag uploaded photos with a tag \"{immich-go}/YYYY-MM-DD HH-MM-SS\"")
+
+	// Batched upload flags
+	flags.IntVar(&uc.BatchLimit, "batch-limit", 0, "Process at most N months then stop (0 = unlimited)")
+	flags.StringVar(&uc.StateDir, "state-dir", "", "Override state directory (default: ~/.config/immich-go/state/)")
+	flags.BoolVar(&uc.ResetState, "reset-state", false, "Clear saved state and start fresh")
+	flags.BoolVar(&uc.ShowState, "show-state", false, "Print current state (completed/remaining months) and exit")
 
 	uc.StackOptions.RegisterFlags(flags)
 }
@@ -171,6 +185,18 @@ func (uc *UpCmd) Run(cmd *cobra.Command, adapter adapters.Reader) error {
 	uc.Groupers = append(uc.Groupers, series.Group)
 	uc.Filters = append(uc.Filters, uc.ManageBurst.GroupFilter(), uc.ManageRawJPG.GroupFilter(), uc.ManageHEICJPG.GroupFilter())
 	uc.infoCollector = filenames.NewInfoCollector(uc.tz, uc.app.GetSupportedMedia())
+
+	// Handle --show-state and --reset-state early before full upload setup.
+	// For adapters that don't support batching, these flags are no-ops.
+	if uc.ShowState || uc.ResetState {
+		if _, hasBatching := adapter.(adapters.DateRangeProvider); !hasBatching {
+			// Non-batching adapters don't use state files; inform the user.
+			fmt.Println("State tracking is only available for batched upload sources (e.g., from-icloud).")
+			if uc.ShowState {
+				return nil
+			}
+		}
+	}
 
 	return uc.upload(ctx, adapter)
 }

--- a/app/upload/upload.go
+++ b/app/upload/upload.go
@@ -3,6 +3,7 @@ package upload
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"github.com/simulot/immich-go/adapters"
@@ -12,6 +13,7 @@ import (
 	"github.com/simulot/immich-go/adapters/shared"
 	"github.com/simulot/immich-go/app"
 	"github.com/simulot/immich-go/immich"
+	cliflags "github.com/simulot/immich-go/internal/cliFlags"
 	"github.com/simulot/immich-go/internal/assets"
 	"github.com/simulot/immich-go/internal/assets/cache"
 	"github.com/simulot/immich-go/internal/assettracker"
@@ -87,6 +89,7 @@ type UpCmd struct {
 	currentMonth      string                               // current month being processed in batched mode
 	batchCurrent      int                                  // index of current month (1-based)
 	batchTotal        int                                  // total months being processed in this run
+	resumeSkipped     atomic.Int64                         // count of files skipped due to resume state
 }
 
 func (uc *UpCmd) RegisterFlags(flags *pflag.FlagSet) {
@@ -164,6 +167,13 @@ func (uc *UpCmd) Run(cmd *cobra.Command, adapter adapters.Reader) error {
 	}
 	uc.tz = uc.app.GetTZ()
 	uc.app.SetSupportedMedia(uc.client.Immich.SupportedMedia())
+
+	// Enable retry on the immich client when --on-errors=retry
+	if uc.app.OnErrors == cliflags.OnErrorsRetry {
+		if ic, ok := uc.client.Immich.(*immich.ImmichClient); ok {
+			ic.RetryEnabled = true
+		}
+	}
 
 	// Initialize the FileProcessor if not already done
 	if uc.app.FileProcessor() == nil {

--- a/app/upload/upload.go
+++ b/app/upload/upload.go
@@ -85,6 +85,8 @@ type UpCmd struct {
 	infoCollector     *filenames.InfoCollector             // Collects information about the files being processed
 	state             *State                               // runtime state tracking for batched uploads
 	currentMonth      string                               // current month being processed in batched mode
+	batchCurrent      int                                  // index of current month (1-based)
+	batchTotal        int                                  // total months being processed in this run
 }
 
 func (uc *UpCmd) RegisterFlags(flags *pflag.FlagSet) {

--- a/app/upload/upload.go
+++ b/app/upload/upload.go
@@ -90,6 +90,7 @@ type UpCmd struct {
 	batchCurrent      int                                  // index of current month (1-based)
 	batchTotal        int                                  // total months being processed in this run
 	resumeSkipped     atomic.Int64                         // count of files skipped due to resume state
+	immichUpdateFn    progressUpdate                       // callback for Immich asset reading progress (set by UI)
 }
 
 func (uc *UpCmd) RegisterFlags(flags *pflag.FlagSet) {

--- a/app/upload/upload.go
+++ b/app/upload/upload.go
@@ -78,6 +78,7 @@ type UpCmd struct {
 	assetIndex        *immichIndex                         // List of assets present on the server
 	localAssets       *syncset.Set[string]                 // List of assets present on the local input by name+size
 	immichAssetsReady chan struct{}                        // Signal that the asset index is ready
+	immichAlbumsReady chan struct{}                        // Signal that server albums have been merged into albumsCache
 	deleteServerList  []*immich.Asset                      // List of server assets to remove
 	adapter           adapters.Reader                      // the source of assets
 	DebugCounters     bool                                 // Enable CSV action counters per file
@@ -91,6 +92,8 @@ type UpCmd struct {
 	batchTotal        int                                  // total months being processed in this run
 	resumeSkipped     atomic.Int64                         // count of files skipped due to resume state
 	immichUpdateFn    progressUpdate                       // callback for Immich asset reading progress (set by UI)
+	cachedAlbums      []albumResult                        // cached album details from server (fetched once)
+	albumsFetched     bool                                 // true after album details have been fetched
 }
 
 func (uc *UpCmd) RegisterFlags(flags *pflag.FlagSet) {

--- a/cmd/fix-albums/main.go
+++ b/cmd/fix-albums/main.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/simulot/immich-go/immich"
+)
+
+func main() {
+	server := flag.String("server", "", "Immich server URL (e.g. http://synology:2283)")
+	apiKey := flag.String("api-key", "", "Immich API key")
+	dryRun := flag.Bool("dry-run", true, "Show what would be done without making changes (default: true)")
+	flag.Parse()
+
+	if *server == "" || *apiKey == "" {
+		fmt.Fprintln(os.Stderr, "Usage: fix-albums --server URL --api-key KEY [--dry-run=false]")
+		os.Exit(1)
+	}
+
+	ctx := context.Background()
+
+	ic, err := immich.NewImmichClient(*server, *apiKey)
+	if err != nil {
+		log.Fatalf("Failed to connect to Immich: %v", err)
+	}
+
+	user, err := ic.ValidateConnection(ctx)
+	if err != nil {
+		log.Fatalf("Failed to validate connection: %v", err)
+	}
+	fmt.Printf("Connected as: %s %s (%s)\n", user.FirstName, user.LastName, user.Email)
+
+	// Get all albums
+	albums, err := ic.GetAllAlbums(ctx)
+	if err != nil {
+		log.Fatalf("Failed to get albums: %v", err)
+	}
+	fmt.Printf("Found %d albums\n\n", len(albums))
+
+	// Pattern: album name ending with digits directly after a letter (no space/punctuation).
+	// This matches iCloud CSV chunk suffixes like "Trip1", "Trip10" but not "Summer 2022".
+	// e.g. "Memory Cooking Over the Years3" -> base "Memory Cooking Over the Years"
+	suffixPattern := regexp.MustCompile(`^(.*[a-zA-Z_])(\d+)$`)
+
+	// Group albums by base name
+	type albumInfo struct {
+		id   string
+		name string
+	}
+
+	groups := make(map[string][]albumInfo)
+	for _, a := range albums {
+		baseName := a.AlbumName
+		if m := suffixPattern.FindStringSubmatch(a.AlbumName); m != nil {
+			// Only treat as duplicate if the base name also exists
+			baseName = m[1]
+		}
+		groups[baseName] = append(groups[baseName], albumInfo{id: a.ID, name: a.AlbumName})
+	}
+
+	// Find groups with duplicates
+	var duplicateGroups []string
+	for baseName, group := range groups {
+		if len(group) > 1 {
+			duplicateGroups = append(duplicateGroups, baseName)
+		}
+	}
+	sort.Strings(duplicateGroups)
+
+	if len(duplicateGroups) == 0 {
+		fmt.Println("No duplicate albums found.")
+		return
+	}
+
+	fmt.Printf("Found %d album groups with duplicates:\n\n", len(duplicateGroups))
+
+	totalMerged := 0
+	totalDeleted := 0
+
+	for _, baseName := range duplicateGroups {
+		group := groups[baseName]
+
+		// Sort: original (exact base name) first, then by suffix number
+		sort.Slice(group, func(i, j int) bool {
+			if group[i].name == baseName {
+				return true
+			}
+			if group[j].name == baseName {
+				return false
+			}
+			return group[i].name < group[j].name
+		})
+
+		// The first one should be the original
+		original := group[0]
+		duplicates := group[1:]
+
+		// Verify the original is actually the base name
+		if original.name != baseName {
+			fmt.Printf("  SKIP: No original album found for base name %q (only suffixed versions exist)\n", baseName)
+			continue
+		}
+
+		fmt.Printf("  Album: %q\n", baseName)
+		fmt.Printf("    Original: %s (id: %s)\n", original.name, original.id)
+
+		for _, dup := range duplicates {
+			// Get assets from the duplicate album
+			albumContent, err := ic.GetAlbumInfo(ctx, dup.id, false)
+			if err != nil {
+				fmt.Printf("    ERROR getting album %q: %v\n", dup.name, err)
+				continue
+			}
+
+			assetIDs := make([]string, 0, len(albumContent.Assets))
+			for _, a := range albumContent.Assets {
+				assetIDs = append(assetIDs, a.ID)
+			}
+
+			fmt.Printf("    Duplicate: %s (%d assets) -> merge into %q\n", dup.name, len(assetIDs), original.name)
+
+			if *dryRun {
+				totalMerged += len(assetIDs)
+				totalDeleted++
+				continue
+			}
+
+			// Move assets to original album
+			if len(assetIDs) > 0 {
+				_, err = ic.AddAssetToAlbum(ctx, original.id, assetIDs)
+				if err != nil {
+					fmt.Printf("    ERROR adding assets to %q: %v\n", original.name, err)
+					continue
+				}
+				totalMerged += len(assetIDs)
+			}
+
+			// Delete the duplicate album
+			err = ic.DeleteAlbum(ctx, dup.id)
+			if err != nil {
+				fmt.Printf("    ERROR deleting album %q: %v\n", dup.name, err)
+				continue
+			}
+			totalDeleted++
+			fmt.Printf("    Deleted: %s\n", dup.name)
+		}
+		fmt.Println()
+	}
+
+	if *dryRun {
+		fmt.Println(strings.Repeat("-", 50))
+		fmt.Printf("DRY RUN: Would merge %d assets and delete %d duplicate albums.\n", totalMerged, totalDeleted)
+		fmt.Println("Run with --dry-run=false to apply changes.")
+	} else {
+		fmt.Printf("Done: merged %d assets, deleted %d duplicate albums.\n", totalMerged, totalDeleted)
+	}
+}

--- a/immich/call.go
+++ b/immich/call.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 	"sync/atomic"
 
 	"github.com/simulot/immich-go/internal/assets"
@@ -218,6 +219,36 @@ func putRequest(url string, opts ...serverRequestOption) requestFunction {
 }
 
 func (sc *serverCall) do(fnRequest requestFunction, opts ...serverResponseOption) error {
+	maxAttempts := 1
+	if sc.ic.RetryEnabled {
+		maxAttempts = maxRetries
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if attempt > 0 {
+			delay := retryDelay(attempt-1, "")
+			select {
+			case <-time.After(delay):
+			case <-sc.ctx.Done():
+				return sc.ctx.Err()
+			}
+			// Reset error state for retry
+			sc.err = nil
+		}
+
+		lastErr = sc.doOnce(fnRequest, opts...)
+		if lastErr == nil {
+			return nil
+		}
+		if !isRetryable(lastErr) {
+			return lastErr
+		}
+	}
+	return lastErr
+}
+
+func (sc *serverCall) doOnce(fnRequest requestFunction, opts ...serverResponseOption) error {
 	var (
 		resp *http.Response
 		err  error

--- a/immich/call_test.go
+++ b/immich/call_test.go
@@ -89,3 +89,96 @@ func TestCall(t *testing.T) {
 		})
 	}
 }
+
+func TestCallRetry_TransientError(t *testing.T) {
+	attempts := 0
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts < 3 {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			w.Write([]byte(`{"error":"Service Unavailable","statusCode":503,"message":"overloaded"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status":"ok"}`))
+	})
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	ic, err := NewImmichClient(server.URL, "key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ic.RetryEnabled = true
+
+	r := map[string]string{}
+	err = ic.newServerCall(context.Background(), "test").
+		do(getRequest("/test", setAcceptJSON()), responseJSON(&r))
+	if err != nil {
+		t.Errorf("expected success after retries, got error: %v", err)
+	}
+	if attempts != 3 {
+		t.Errorf("expected 3 attempts, got %d", attempts)
+	}
+}
+
+func TestCallRetry_NonRetryableError(t *testing.T) {
+	attempts := 0
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte(`{"error":"Forbidden","statusCode":403,"message":"no access"}`))
+	})
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	ic, err := NewImmichClient(server.URL, "key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ic.RetryEnabled = true
+
+	r := map[string]string{}
+	err = ic.newServerCall(context.Background(), "test").
+		do(getRequest("/test", setAcceptJSON()), responseJSON(&r))
+	if err == nil {
+		t.Error("expected error for 403, got nil")
+	}
+	if attempts != 1 {
+		t.Errorf("expected 1 attempt (no retry for 403), got %d", attempts)
+	}
+}
+
+func TestCallRetry_Disabled(t *testing.T) {
+	attempts := 0
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		w.Write([]byte(`{"error":"Service Unavailable","statusCode":503,"message":"overloaded"}`))
+	})
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	ic, err := NewImmichClient(server.URL, "key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// RetryEnabled defaults to false
+
+	r := map[string]string{}
+	err = ic.newServerCall(context.Background(), "test").
+		do(getRequest("/test", setAcceptJSON()), responseJSON(&r))
+	if err == nil {
+		t.Error("expected error, got nil")
+	}
+	if attempts != 1 {
+		t.Errorf("expected 1 attempt (retry disabled), got %d", attempts)
+	}
+}

--- a/immich/client.go
+++ b/immich/client.go
@@ -25,6 +25,7 @@ type ImmichClient struct {
 	DeviceUUID     string        // Device
 	Retries        int           // Number of attempts on 500 errors
 	RetriesDelay   time.Duration // Duration between retries
+	RetryEnabled   bool          // If true, retry transient server errors
 	apiTraceWriter io.Writer     // If not nil, logs API calls to this writer
 
 	supportedMediaTypes filetypes.SupportedMedia // Server's list of supported medias

--- a/immich/retry.go
+++ b/immich/retry.go
@@ -31,10 +31,20 @@ func isRetryable(err error) bool {
 		return false
 	}
 
-	// Check for callError with retryable status code
+	// Check for callError with retryable status code.
+	// When status is 0 (no HTTP response — network failed before server replied),
+	// check the underlying error for retryability.
 	var ce callError
 	if errors.As(err, &ce) {
-		return retryableStatusCodes[ce.status]
+		if ce.status > 0 {
+			return retryableStatusCodes[ce.status]
+		}
+		// No HTTP status: network error occurred before response.
+		// Check the wrapped error.
+		if ce.err != nil {
+			return isRetryable(ce.err)
+		}
+		return false
 	}
 
 	// Check for network errors
@@ -43,8 +53,11 @@ func isRetryable(err error) bool {
 		return true
 	}
 
-	// Connection refused / reset
+	// Connection refused / reset / closed
 	if errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, syscall.ECONNRESET) {
+		return true
+	}
+	if errors.Is(err, net.ErrClosed) {
 		return true
 	}
 

--- a/immich/retry.go
+++ b/immich/retry.go
@@ -61,8 +61,8 @@ func isRetryable(err error) bool {
 		return true
 	}
 
-	// EOF errors (server dropped connection)
-	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+	// EOF / closed pipe errors (server dropped connection)
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.ErrClosedPipe) {
 		return true
 	}
 

--- a/immich/retry.go
+++ b/immich/retry.go
@@ -1,0 +1,79 @@
+package immich
+
+import (
+	"errors"
+	"io"
+	"math/rand/v2"
+	"net"
+	"net/http"
+	"strconv"
+	"syscall"
+	"time"
+)
+
+const maxRetries = 3
+
+// retryableStatusCodes is the set of HTTP status codes that are safe to retry.
+var retryableStatusCodes = map[int]bool{
+	http.StatusRequestTimeout:     true, // 408
+	http.StatusTooManyRequests:    true, // 429
+	http.StatusInternalServerError: true, // 500
+	http.StatusBadGateway:         true, // 502
+	http.StatusServiceUnavailable: true, // 503
+	http.StatusGatewayTimeout:     true, // 504
+}
+
+// isRetryable returns true if the error is a transient server or network error
+// that is safe to retry. Permission errors (401, 403) and client errors (400, 404, 409)
+// are NOT retryable.
+func isRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Check for callError with retryable status code
+	var ce callError
+	if errors.As(err, &ce) {
+		return retryableStatusCodes[ce.status]
+	}
+
+	// Check for network errors
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+
+	// Connection refused / reset
+	if errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, syscall.ECONNRESET) {
+		return true
+	}
+
+	// EOF errors (server dropped connection)
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+
+	return false
+}
+
+// IsRetryable is the exported version for use by the upload layer.
+func IsRetryable(err error) bool {
+	return isRetryable(err)
+}
+
+// retryDelay calculates the delay before the next retry attempt.
+// Uses exponential backoff (1s, 2s, 4s) with random jitter (0-1s).
+// If retryAfter is a valid number of seconds (from Retry-After header),
+// that value is used as the base instead.
+func retryDelay(attempt int, retryAfter string) time.Duration {
+	base := time.Duration(1<<uint(attempt)) * time.Second
+
+	if retryAfter != "" {
+		if seconds, err := strconv.Atoi(retryAfter); err == nil && seconds > 0 {
+			base = time.Duration(seconds) * time.Second
+		}
+	}
+
+	jitter := time.Duration(rand.Int64N(int64(time.Second)))
+	return base + jitter
+}

--- a/immich/retry_test.go
+++ b/immich/retry_test.go
@@ -1,0 +1,72 @@
+package immich
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestIsRetryable(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{"nil error", nil, false},
+		{"500 error", callError{status: http.StatusInternalServerError}, true},
+		{"502 error", callError{status: http.StatusBadGateway}, true},
+		{"503 error", callError{status: http.StatusServiceUnavailable}, true},
+		{"504 error", callError{status: http.StatusGatewayTimeout}, true},
+		{"408 error", callError{status: http.StatusRequestTimeout}, true},
+		{"429 error", callError{status: http.StatusTooManyRequests}, true},
+		{"400 error", callError{status: http.StatusBadRequest}, false},
+		{"401 error", callError{status: http.StatusUnauthorized}, false},
+		{"403 error", callError{status: http.StatusForbidden}, false},
+		{"404 error", callError{status: http.StatusNotFound}, false},
+		{"409 error", callError{status: http.StatusConflict}, false},
+		{"connection refused", fmt.Errorf("connect: %w", syscall.ECONNREFUSED), true},
+		{"connection reset", fmt.Errorf("read: %w", syscall.ECONNRESET), true},
+		{"EOF", io.EOF, true},
+		{"unexpected EOF", io.ErrUnexpectedEOF, true},
+		{"net timeout", netTimeoutError{}, true},
+		{"wrapped retryable", fmt.Errorf("outer: %w", callError{status: 503}), true},
+		{"generic error", errors.New("something"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isRetryable(tt.err)
+			if got != tt.expected {
+				t.Errorf("isRetryable(%v) = %v, want %v", tt.err, got, tt.expected)
+			}
+		})
+	}
+}
+
+// netTimeoutError implements net.Error with Timeout() = true
+type netTimeoutError struct{}
+
+func (e netTimeoutError) Error() string   { return "timeout" }
+func (e netTimeoutError) Timeout() bool   { return true }
+func (e netTimeoutError) Temporary() bool { return true }
+
+func TestRetryDelay(t *testing.T) {
+	for attempt := 0; attempt < 3; attempt++ {
+		d := retryDelay(attempt, "")
+		base := time.Duration(1<<uint(attempt)) * time.Second
+		if d < base || d > base+time.Second {
+			t.Errorf("attempt %d: delay %v outside expected range [%v, %v]", attempt, d, base, base+time.Second)
+		}
+	}
+}
+
+func TestRetryDelay_RetryAfter(t *testing.T) {
+	d := retryDelay(0, "5")
+	if d < 5*time.Second || d > 6*time.Second {
+		t.Errorf("with Retry-After=5, got %v, expected ~5s", d)
+	}
+}

--- a/immich/retry_test.go
+++ b/immich/retry_test.go
@@ -37,6 +37,8 @@ func TestIsRetryable(t *testing.T) {
 		{"wrapped retryable", fmt.Errorf("outer: %w", callError{status: 503}), true},
 		{"closed network connection", net.ErrClosed, true},
 		{"wrapped closed connection", fmt.Errorf("write tcp: %w", net.ErrClosed), true},
+		{"closed pipe", io.ErrClosedPipe, true},
+		{"wrapped closed pipe", fmt.Errorf("upload: %w", io.ErrClosedPipe), true},
 		{"callError wrapping network error", callError{status: 0, err: net.ErrClosed}, true},
 		{"callError wrapping connection reset", callError{status: 0, err: syscall.ECONNRESET}, true},
 		{"callError wrapping EOF", callError{status: 0, err: io.EOF}, true},

--- a/immich/retry_test.go
+++ b/immich/retry_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"syscall"
 	"testing"
@@ -34,6 +35,12 @@ func TestIsRetryable(t *testing.T) {
 		{"unexpected EOF", io.ErrUnexpectedEOF, true},
 		{"net timeout", netTimeoutError{}, true},
 		{"wrapped retryable", fmt.Errorf("outer: %w", callError{status: 503}), true},
+		{"closed network connection", net.ErrClosed, true},
+		{"wrapped closed connection", fmt.Errorf("write tcp: %w", net.ErrClosed), true},
+		{"callError wrapping network error", callError{status: 0, err: net.ErrClosed}, true},
+		{"callError wrapping connection reset", callError{status: 0, err: syscall.ECONNRESET}, true},
+		{"callError wrapping EOF", callError{status: 0, err: io.EOF}, true},
+		{"callError with 400 and network err", callError{status: 400, err: net.ErrClosed}, false},
 		{"generic error", errors.New("something"), false},
 	}
 

--- a/immich/upload.go
+++ b/immich/upload.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/simulot/immich-go/internal/assets"
@@ -40,6 +41,35 @@ func (ic *ImmichClient) uploadAsset(ctx context.Context, la *assets.Asset, endPo
 		}, nil
 	}
 
+	maxAttempts := 1
+	if ic.RetryEnabled {
+		maxAttempts = maxRetries
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if attempt > 0 {
+			delay := retryDelay(attempt-1, "")
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				return AssetResponse{}, ctx.Err()
+			}
+		}
+
+		ar, err := ic.uploadAssetOnce(ctx, la, endPoint, replaceID)
+		if err == nil {
+			return ar, nil
+		}
+		if !isRetryable(err) {
+			return ar, err
+		}
+		lastErr = err
+	}
+	return AssetResponse{}, lastErr
+}
+
+func (ic *ImmichClient) uploadAssetOnce(ctx context.Context, la *assets.Asset, endPoint string, replaceID string) (AssetResponse, error) {
 	var ar AssetResponse
 	ext := path.Ext(la.OriginalFileName)
 	if strings.TrimSuffix(la.OriginalFileName, ext) == "" {

--- a/immich/upload.go
+++ b/immich/upload.go
@@ -132,14 +132,17 @@ func (ic *ImmichClient) uploadAssetOnce(ctx context.Context, la *assets.Asset, e
 		errChan <- nil
 	}()
 
+	// Use doOnce (not do) because the multipart pipe body cannot be re-read.
+	// The outer retry loop in uploadAsset handles retries by re-opening the file
+	// and creating a fresh pipe.
 	var errCall error
 	switch endPoint {
 	case EndPointAssetUpload:
-		errCall = ic.newServerCall(ctx, EndPointAssetUpload).
-			do(postRequest("/assets", m.FormDataContentType(), setContextValue(callValues), setAcceptJSON(), setImmichChecksum(la), setBody(body)), responseJSON(&ar))
+		sc := ic.newServerCall(ctx, EndPointAssetUpload)
+		errCall = sc.doOnce(postRequest("/assets", m.FormDataContentType(), setContextValue(callValues), setAcceptJSON(), setImmichChecksum(la), setBody(body)), responseJSON(&ar))
 	case EndPointAssetReplace:
-		errCall = ic.newServerCall(ctx, EndPointAssetReplace).
-			do(putRequest("/assets/"+replaceID+"/original", setContextValue(callValues), setAcceptJSON(), setImmichChecksum(la), setContentType(m.FormDataContentType()), setBody(body)), responseJSON(&ar))
+		sc := ic.newServerCall(ctx, EndPointAssetReplace)
+		errCall = sc.doOnce(putRequest("/assets/"+replaceID+"/original", setContextValue(callValues), setAcceptJSON(), setImmichChecksum(la), setContentType(m.FormDataContentType()), setBody(body)), responseJSON(&ar))
 	}
 	if ar.Status == "duplicate" && errors.Is(err, io.ErrClosedPipe) {
 		err = nil // immich closes the connection when we upload the x-immich-checksum header and it finds a duplicate

--- a/internal/assets/asset.go
+++ b/internal/assets/asset.go
@@ -103,6 +103,18 @@ func (a *Asset) SetNameInfo(ni NameInfo) {
 	a.NameInfo = ni
 }
 
+// BestDate returns the best available date for the asset, following the
+// resolution order: CaptureDate, FileDate, NameInfo.Taken.
+func (a *Asset) BestDate() time.Time {
+	if !a.CaptureDate.IsZero() {
+		return a.CaptureDate
+	}
+	if !a.FileDate.IsZero() {
+		return a.FileDate
+	}
+	return a.Taken
+}
+
 func (a *Asset) UseMetadata(md *Metadata) *Metadata {
 	if md == nil {
 		return nil

--- a/internal/assettracker/tracker.go
+++ b/internal/assettracker/tracker.go
@@ -329,6 +329,15 @@ func (at *AssetTracker) GenerateReport() string {
 		report += fmt.Sprintf("\n⚠️  WARNING: %d assets did not reach a final state!\n", counters.Pending)
 	}
 
+	// List individual errors
+	if counters.Errors > 0 {
+		errors := at.GetErrors()
+		report += "\nFailed files:\n"
+		for _, e := range errors {
+			report += fmt.Sprintf("  %s: %s (%s)\n", e.EventCode, e.File.FullName(), e.Reason)
+		}
+	}
+
 	return report
 }
 
@@ -413,6 +422,20 @@ func (at *AssetTracker) GetErrorSize() int64 {
 	at.mu.RLock()
 	defer at.mu.RUnlock()
 	return at.errorSize
+}
+
+// GetErrors returns all assets in the ERROR state
+func (at *AssetTracker) GetErrors() []AssetRecord {
+	at.mu.RLock()
+	defer at.mu.RUnlock()
+
+	var errs []AssetRecord
+	for _, record := range at.assets {
+		if record.State == StateError {
+			errs = append(errs, *record)
+		}
+	}
+	return errs
 }
 
 // formatBytes formats byte count as human-readable string

--- a/internal/cliFlags/orErrors.go
+++ b/internal/cliFlags/orErrors.go
@@ -16,10 +16,11 @@ const (
 	OnErrorsStop OnErrorsFlag = iota
 	OnErrorsStopAfter
 	OnErrorsNeverStop = -1
+	OnErrorsRetry     = -2
 )
 
 func (f *OnErrorsFlag) RegisterFlags(fs *pflag.FlagSet, prefix string) {
-	fs.Var(f, prefix+"on-errors", "Action to take on errors, (stop|continue| <n> errors)")
+	fs.Var(f, prefix+"on-errors", "Action to take on errors (stop|continue|retry|N)")
 }
 
 func (f OnErrorsFlag) String() string {
@@ -28,6 +29,8 @@ func (f OnErrorsFlag) String() string {
 		return "stop"
 	case f == OnErrorsNeverStop:
 		return "continue"
+	case f == OnErrorsRetry:
+		return "retry"
 	case f >= OnErrorsStopAfter:
 		return fmt.Sprintf("%d", f)
 	default:
@@ -41,6 +44,8 @@ func (f *OnErrorsFlag) Set(value string) error {
 		*f = OnErrorsStop
 	case "continue":
 		*f = OnErrorsNeverStop
+	case "retry":
+		*f = OnErrorsRetry
 	default:
 		n, err := strconv.Atoi(value)
 		if err != nil {

--- a/internal/cliFlags/orErrors_test.go
+++ b/internal/cliFlags/orErrors_test.go
@@ -1,0 +1,40 @@
+package cliflags
+
+import "testing"
+
+func TestOnErrorsFlag_SetAndString(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected OnErrorsFlag
+		str      string
+		wantErr  bool
+	}{
+		{"stop", OnErrorsStop, "stop", false},
+		{"continue", OnErrorsNeverStop, "continue", false},
+		{"retry", OnErrorsRetry, "retry", false},
+		{"5", OnErrorsFlag(5), "5", false},
+		{"invalid", 0, "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			var f OnErrorsFlag
+			err := f.Set(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if f != tt.expected {
+				t.Errorf("got %v, want %v", f, tt.expected)
+			}
+			if f.String() != tt.str {
+				t.Errorf("String() = %q, want %q", f.String(), tt.str)
+			}
+		})
+	}
+}

--- a/internal/gen/maps.go
+++ b/internal/gen/maps.go
@@ -79,3 +79,15 @@ func (m *SyncMap[K, V]) Keys() []K {
 	}
 	return r
 }
+
+// Range calls f for each key-value pair in the map.
+// If f returns false, Range stops iteration.
+func (m *SyncMap[K, V]) Range(f func(K, V) bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for k, v := range m.m {
+		if !f(k, v) {
+			return
+		}
+	}
+}

--- a/internal/worker/throttle.go
+++ b/internal/worker/throttle.go
@@ -40,19 +40,33 @@ func (t *Throttle) Release() {
 	<-sem
 }
 
-// SetConcurrency changes the concurrency level by replacing the semaphore channel.
-// In-flight tasks continue to hold slots on the old channel; new tasks use the new one.
+// SetConcurrency adjusts the concurrency level by draining or adding tokens
+// to the existing semaphore channel. In-flight workers are not affected because
+// they acquired/release on the same channel instance.
 // Minimum concurrency is 1.
 func (t *Throttle) SetConcurrency(n int) {
 	if n < 1 {
 		n = 1
+	}
+	if n > t.max {
+		n = t.max // cannot exceed original capacity (channel buffer size)
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if n == t.current {
 		return
 	}
-	t.sem = make(chan struct{}, n)
+	if n < t.current {
+		// Reduce: fill extra slots so fewer workers can acquire.
+		for i := n; i < t.current; i++ {
+			t.sem <- struct{}{}
+		}
+	} else {
+		// Increase: drain blocked slots to free capacity.
+		for i := t.current; i < n; i++ {
+			<-t.sem
+		}
+	}
 	t.current = n
 }
 

--- a/internal/worker/throttle.go
+++ b/internal/worker/throttle.go
@@ -1,0 +1,72 @@
+package worker
+
+import "sync"
+
+// Throttle controls the level of concurrency using a channel-based semaphore.
+// It can be dynamically adjusted at runtime via SetConcurrency.
+type Throttle struct {
+	sem     chan struct{}
+	current int
+	max     int
+	mu      sync.Mutex
+}
+
+// NewThrottle creates a Throttle with the given initial concurrency level.
+func NewThrottle(n int) *Throttle {
+	if n < 1 {
+		n = 1
+	}
+	t := &Throttle{
+		sem:     make(chan struct{}, n),
+		current: n,
+		max:     n,
+	}
+	return t
+}
+
+// Acquire blocks until a slot is available.
+func (t *Throttle) Acquire() {
+	t.mu.Lock()
+	sem := t.sem
+	t.mu.Unlock()
+	sem <- struct{}{}
+}
+
+// Release frees a slot.
+func (t *Throttle) Release() {
+	t.mu.Lock()
+	sem := t.sem
+	t.mu.Unlock()
+	<-sem
+}
+
+// SetConcurrency changes the concurrency level by replacing the semaphore channel.
+// In-flight tasks continue to hold slots on the old channel; new tasks use the new one.
+// Minimum concurrency is 1.
+func (t *Throttle) SetConcurrency(n int) {
+	if n < 1 {
+		n = 1
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if n == t.current {
+		return
+	}
+	t.sem = make(chan struct{}, n)
+	t.current = n
+}
+
+// Current returns the current concurrency level.
+func (t *Throttle) Current() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.current
+}
+
+// Max returns the original (maximum) concurrency level.
+func (t *Throttle) Max() int {
+	return t.max
+}
+
+// Close is a no-op for compatibility; the throttle doesn't need explicit cleanup.
+func (t *Throttle) Close() {}

--- a/internal/worker/throttle_test.go
+++ b/internal/worker/throttle_test.go
@@ -1,0 +1,75 @@
+package worker
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestThrottle_BasicConcurrency(t *testing.T) {
+	th := NewThrottle(3)
+	defer th.Close()
+
+	var running atomic.Int32
+	var maxSeen atomic.Int32
+	var wg sync.WaitGroup
+
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			th.Acquire()
+			cur := running.Add(1)
+			for {
+				old := maxSeen.Load()
+				if cur <= old || maxSeen.CompareAndSwap(old, cur) {
+					break
+				}
+			}
+			time.Sleep(10 * time.Millisecond)
+			running.Add(-1)
+			th.Release()
+		}()
+	}
+
+	wg.Wait()
+	if maxSeen.Load() > 3 {
+		t.Errorf("max concurrent = %d, want <= 3", maxSeen.Load())
+	}
+}
+
+func TestThrottle_SetConcurrency(t *testing.T) {
+	th := NewThrottle(10)
+	defer th.Close()
+
+	if th.Current() != 10 {
+		t.Errorf("initial concurrency = %d, want 10", th.Current())
+	}
+
+	th.SetConcurrency(5)
+	if th.Current() != 5 {
+		t.Errorf("after SetConcurrency(5) = %d, want 5", th.Current())
+	}
+
+	th.SetConcurrency(0) // should clamp to 1
+	if th.Current() != 1 {
+		t.Errorf("after SetConcurrency(0) = %d, want 1", th.Current())
+	}
+
+	th.SetConcurrency(20)
+	if th.Current() != 20 {
+		t.Errorf("after SetConcurrency(20) = %d, want 20", th.Current())
+	}
+}
+
+func TestThrottle_Max(t *testing.T) {
+	th := NewThrottle(8)
+	if th.Max() != 8 {
+		t.Errorf("Max() = %d, want 8", th.Max())
+	}
+	th.SetConcurrency(3)
+	if th.Max() != 8 {
+		t.Errorf("Max() after SetConcurrency = %d, want 8", th.Max())
+	}
+}

--- a/internal/worker/throttle_test.go
+++ b/internal/worker/throttle_test.go
@@ -57,9 +57,9 @@ func TestThrottle_SetConcurrency(t *testing.T) {
 		t.Errorf("after SetConcurrency(0) = %d, want 1", th.Current())
 	}
 
-	th.SetConcurrency(20)
-	if th.Current() != 20 {
-		t.Errorf("after SetConcurrency(20) = %d, want 20", th.Current())
+	th.SetConcurrency(20) // clamped to max (10)
+	if th.Current() != 10 {
+		t.Errorf("after SetConcurrency(20) = %d, want 10 (clamped to max)", th.Current())
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR adds **batched upload mode** — a month-by-month processing strategy for large photo archives (tested with 567 GB / 17-part iCloud export). Instead of loading all server assets into memory at once, it scopes server queries to each month's date range, dramatically reducing memory usage and enabling resumable uploads.

### Key features

- **Month-by-month batched processing**: Pre-scans archives to discover date ranges, then processes one month at a time with scoped server asset queries
- **Resumable state tracking**: Persists completed months to `~/.config/immich-go/state/` so interrupted uploads resume where they left off (`--reset-state` to start fresh, `--show-state` to inspect)
- **`--batch-limit N`**: Process at most N months per run for controlled rollouts
- **Parallel album fetching**: Fetches album details with 5 concurrent workers and caches results for the entire session (single fetch, not per-month)
- **Retry with adaptive concurrency** (`--on-errors=retry`): Automatically retries failed uploads with exponential backoff, reducing concurrency on repeated failures
- **Error report generation**: Writes a detailed error report file at the end of upload listing all failed files
- **iCloud CSV chunk merging**: Correctly handles Apple's split Memory/Album CSVs (`Trip.csv`, `Trip1.csv`, `Trip2.csv` → single album) with deduplication
- **fix-albums tool**: Standalone utility to detect and merge duplicate albums on an Immich server

### Problems solved

1. **Memory pressure**: Large archives with 50k+ server assets caused OOM. Batched mode only loads one month's assets at a time.

2. **No resume capability**: A crash at 80% meant restarting from scratch. State tracking enables seamless resume.

3. **Duplicate albums from iCloud exports**: Apple splits large Memory CSVs into numbered chunks. Without merging, each chunk created a separate album (e.g., "Memory Austria Trip", "Memory Austria Trip1", "Memory Austria Trip2"). Fixed by stripping iCloud's suffix digits and deduplicating album assignments per file.

4. **Album race condition**: `uploadLoop` could start assigning albums before server albums were loaded into cache, creating duplicates. Fixed with `immichAlbumsReady` synchronization signal.

5. **PreScan missed months for iCloud archives**: iCloud uses UUID filenames (`23b26d4d-...jpg`) so filename-based date extraction returned nothing. PreScan now parses Photo Details CSVs first to discover the actual date ranges.

6. **CSV parsing failure on "null" dates**: A single "null" date value in a Photo Details CSV caused the entire file to be abandoned. Now skips invalid records and continues.

7. **Slow sequential album fetching**: Album details were fetched one-by-one and re-fetched every month. Now fetched in parallel (5 workers) and cached for the session.

### New CLI flags

| Flag | Description |
|------|-------------|
| `--batch-limit N` | Process at most N months then stop (0 = unlimited) |
| `--state-dir PATH` | Override state directory |
| `--reset-state` | Clear saved state and start fresh |
| `--show-state` | Print completed/remaining months and exit |
| `--on-errors=retry` | Enable retry with adaptive concurrency |

### Architecture

The batched upload is activated automatically when the adapter implements the `DateRangeProvider` interface:

```go
type DateRangeProvider interface {
    PreScan(ctx context.Context) ([]string, error)      // returns sorted YYYY-MM months
    BrowseMonth(ctx context.Context, month string) chan *assets.Group
}
```

Currently implemented for: **iCloud** (`from-icloud`), **Google Photos** (`from-google-photos`), and **from-immich** adapters.

State is tracked per source fingerprint (hash of sorted input paths) so multiple upload sources don't interfere.

### Files changed

- `adapters/folder/commands.go` — PreScan with iCloud CSV date extraction
- `adapters/folder/icloud.go` — CSV chunk suffix stripping, null date handling, album dedup
- `adapters/folder/run.go` — `BrowseMonth` with pre-filtering, `matchesTargetMonth`
- `adapters/fromimmich/browsemonth.go` — DateRangeProvider for from-immich
- `adapters/googlePhotos/browsemonth.go` — DateRangeProvider for Google Photos
- `app/upload/run.go` — Batched upload orchestration, parallel album fetch, error reporting
- `app/upload/state.go` — Persistent state tracking
- `app/upload/upload.go` — New fields for batching state
- `app/upload/ui.go` — TUI support for batched mode with month progress
- `immich/retry.go` — Retry with exponential backoff
- `internal/worker/throttle.go` — Adaptive concurrency throttle
- `cmd/fix-albums/main.go` — Standalone duplicate album merger

## Test plan

- [x] Unit tests for PreScan (filename dates, iCloud metas, no-date tracking)
- [x] Unit tests for BrowseMonth date filtering
- [x] Unit tests for state persistence and resume
- [x] Unit tests for retry and throttle
- [x] Unit tests for `--on-errors` flag parsing
- [x] Integration tested with 567 GB iCloud export (17 zip parts, ~11.5k assets)
- [x] Verified duplicate album fix with fix-albums tool (merged 10k+ assets, deleted 380+ duplicates)
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)